### PR TITLE
[Feat] 모임 일정 생성/수정 화면 구현

### DIFF
--- a/Namo_SwiftUI/Namo_SwiftUI.xcodeproj/project.pbxproj
+++ b/Namo_SwiftUI/Namo_SwiftUI.xcodeproj/project.pbxproj
@@ -115,6 +115,7 @@
 		8879A7E92B6A494D00794475 /* Data+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A7E82B6A494D00794475 /* Data+.swift */; };
 		8879A7ED2B6A521B00794475 /* APITask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A7EC2B6A521B00794475 /* APITask.swift */; };
 		889C74152BCADCC0005937CB /* MoimScheduleTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889C74142BCADCC0005937CB /* MoimScheduleTemplate.swift */; };
+		889C74182BCADD5C005937CB /* GroupToDoEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889C74172BCADD5C005937CB /* GroupToDoEditView.swift */; };
 		889EE0E12B888EC100F2FFB3 /* PlaceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889EE0E02B888EC100F2FFB3 /* PlaceRepository.swift */; };
 		889EE0E32B888ED100F2FFB3 /* PlaceRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889EE0E22B888ED100F2FFB3 /* PlaceRepositoryImpl.swift */; };
 		889EE0E62B88915700F2FFB3 /* PlaceEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889EE0E52B88915700F2FFB3 /* PlaceEndPoint.swift */; };
@@ -249,6 +250,7 @@
 		8879A7E82B6A494D00794475 /* Data+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+.swift"; sourceTree = "<group>"; };
 		8879A7EC2B6A521B00794475 /* APITask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITask.swift; sourceTree = "<group>"; };
 		889C74142BCADCC0005937CB /* MoimScheduleTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoimScheduleTemplate.swift; sourceTree = "<group>"; };
+		889C74172BCADD5C005937CB /* GroupToDoEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupToDoEditView.swift; sourceTree = "<group>"; };
 		889EE0E02B888EC100F2FFB3 /* PlaceRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceRepository.swift; sourceTree = "<group>"; };
 		889EE0E22B888ED100F2FFB3 /* PlaceRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceRepositoryImpl.swift; sourceTree = "<group>"; };
 		889EE0E52B88915700F2FFB3 /* PlaceEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceEndPoint.swift; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 		5012A9E22B593A9E00544AB0 /* Group */ = {
 			isa = PBXGroup;
 			children = (
+				889C74162BCADD4F005937CB /* GroupToDo */,
 				5021D8E82B594069009B4AD1 /* GroupMain */,
 				2CF445252B83516400A8E514 /* GroupCalendarView.swift */,
 			);
@@ -825,6 +828,14 @@
 			path = EndPoint;
 			sourceTree = "<group>";
 		};
+		889C74162BCADD4F005937CB /* GroupToDo */ = {
+			isa = PBXGroup;
+			children = (
+				889C74172BCADD5C005937CB /* GroupToDoEditView.swift */,
+			);
+			path = GroupToDo;
+			sourceTree = "<group>";
+		};
 		889EE0DF2B888EAE00F2FFB3 /* Place */ = {
 			isa = PBXGroup;
 			children = (
@@ -1078,6 +1089,7 @@
 				2CF4451C2B7FA0C300A8E514 /* GroupListItem.swift in Sources */,
 				88D6C9F82B6028B3004742AD /* ToDoEditView.swift in Sources */,
 				88D6C9F82B6028B3004742AD /* ToDoEditView.swift in Sources */,
+				889C74182BCADD5C005937CB /* GroupToDoEditView.swift in Sources */,
 				8834ADFD2B67CAE00024F724 /* EndPoint.swift in Sources */,
 				88EFE4602B87C7680085826B /* PlaceInteractor.swift in Sources */,
 				2CF4450A2B78E3C700A8E514 /* CategoryDTO.swift in Sources */,

--- a/Namo_SwiftUI/Namo_SwiftUI.xcodeproj/project.pbxproj
+++ b/Namo_SwiftUI/Namo_SwiftUI.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		8879A7E62B69285700794475 /* Example_ScheduleEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A7E52B69285700794475 /* Example_ScheduleEndPoint.swift */; };
 		8879A7E92B6A494D00794475 /* Data+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A7E82B6A494D00794475 /* Data+.swift */; };
 		8879A7ED2B6A521B00794475 /* APITask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A7EC2B6A521B00794475 /* APITask.swift */; };
+		889C74152BCADCC0005937CB /* MoimScheduleTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889C74142BCADCC0005937CB /* MoimScheduleTemplate.swift */; };
 		889EE0E12B888EC100F2FFB3 /* PlaceRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889EE0E02B888EC100F2FFB3 /* PlaceRepository.swift */; };
 		889EE0E32B888ED100F2FFB3 /* PlaceRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889EE0E22B888ED100F2FFB3 /* PlaceRepositoryImpl.swift */; };
 		889EE0E62B88915700F2FFB3 /* PlaceEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889EE0E52B88915700F2FFB3 /* PlaceEndPoint.swift */; };
@@ -247,6 +248,7 @@
 		8879A7E52B69285700794475 /* Example_ScheduleEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Example_ScheduleEndPoint.swift; sourceTree = "<group>"; };
 		8879A7E82B6A494D00794475 /* Data+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+.swift"; sourceTree = "<group>"; };
 		8879A7EC2B6A521B00794475 /* APITask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITask.swift; sourceTree = "<group>"; };
+		889C74142BCADCC0005937CB /* MoimScheduleTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoimScheduleTemplate.swift; sourceTree = "<group>"; };
 		889EE0E02B888EC100F2FFB3 /* PlaceRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceRepository.swift; sourceTree = "<group>"; };
 		889EE0E22B888ED100F2FFB3 /* PlaceRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceRepositoryImpl.swift; sourceTree = "<group>"; };
 		889EE0E52B88915700F2FFB3 /* PlaceEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceEndPoint.swift; sourceTree = "<group>"; };
@@ -418,6 +420,7 @@
 				8879A7DF2B6927E300794475 /* DTO */,
 				884382D42B74D5EA00766503 /* Place.swift */,
 				88E48F7D2B820FFD00B064A0 /* ScheduleTemplate.swift */,
+				889C74142BCADCC0005937CB /* MoimScheduleTemplate.swift */,
 				8862E6372B839F760004DE4B /* ScheduleCategory.swift */,
 				889EE0E72B8B234200F2FFB3 /* NotificationSetting.swift */,
 				2CFE00542B73658A0054C31B /* Schedule.swift */,
@@ -1027,6 +1030,7 @@
 				2CFE00202B6F50890054C31B /* CalendarScheduleItem.swift in Sources */,
 				2CFE00282B70C2580054C31B /* ScheduleRepositoryImpl.swift in Sources */,
 				2C0F71472BBA42660073A8E3 /* NotificationName+.swift in Sources */,
+				889C74152BCADCC0005937CB /* MoimScheduleTemplate.swift in Sources */,
 				2C13052A2BA3CFFA0002175D /* RealmSchedule.swift in Sources */,
 				8862E6382B839F760004DE4B /* ScheduleCategory.swift in Sources */,
 				50299F282BA11BCB007CCDB7 /* CategoryAddView.swift in Sources */,

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/AppState.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/AppState.swift
@@ -25,7 +25,10 @@ struct PlaceState {
 }
 
 class ScheduleState: ObservableObject {
+    /// 개인 일정 생성/수정을 위한 스케줄 템플릿
 	@Published var currentSchedule: ScheduleTemplate = ScheduleTemplate()
+    /// 모임 일정 생성./수정을 위한 스케줄 템플릿
+    @Published var currentMoimSchedule: MoimScheduleTemplate = MoimScheduleTemplate()
 	
 	/// calendar에 보여지기 위한 스케쥴들
 	@Published var calendarSchedules: [YearMonthDay: [CalendarSchedule]] = [:]

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractor.swift
@@ -10,4 +10,7 @@ protocol MoimInteractor {
 	func changeMoimName(moimId: Int, newName: String) async -> Bool
 	func withdrawGroup(moimId: Int) async -> Bool
 	func getMoimSchedule(moimId: Int) async
+    func postNewMoimSchedule() async
+    func patchMoimSchedule() async
+    func deleteMoimSchedule() async
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractor.swift
@@ -13,4 +13,7 @@ protocol MoimInteractor {
     func postNewMoimSchedule() async
     func patchMoimSchedule() async
     func deleteMoimSchedule() async
+    func setPlaceToCurrentMoimSchedule()
+    func setScheduleToCurrentMoimSchedule(schedule: MoimSchedule?)
+    func setSelectedUserListToCurrentMoimSchedule(list: [MoimUser])
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractorImpl.swift
@@ -222,4 +222,36 @@ struct MoimInteractorImpl: MoimInteractor {
         let result = await moimRepository.deleteMoimSchedule(scheduleId: scheduleId)
         print(String(describing: result))
     }
+    
+    /// 지도에서 선택한 selectedPlace의 정보를 currentMoimSchedule에 저장합니다
+    func setPlaceToCurrentMoimSchedule() {
+        if let place = appState.placeState.selectedPlace {
+            scheduleState.currentMoimSchedule.locationName = place.name
+            scheduleState.currentMoimSchedule.x = place.x
+            scheduleState.currentMoimSchedule.y = place.y
+        }
+    }
+    
+    /// 홈 화면에서 선택한 Schedule을 Edit 화면에서 사용할 currentMoimSchedule로 저장합니다.
+    /// nil로 입력 받는 경우 모두 기본값으로 생성합니다.
+    func setScheduleToCurrentMoimSchedule(schedule: MoimSchedule?) {
+        
+        DispatchQueue.main.async {
+            scheduleState.currentMoimSchedule = MoimScheduleTemplate(
+                moimScheduleId: schedule?.moimScheduleId,
+                name: schedule?.name,
+                startDate: schedule?.startDate,
+                endDate: schedule?.endDate,
+                x: schedule?.x,
+                y: schedule?.y,
+                locationName: schedule?.locationName,
+                users: schedule?.users
+            )
+        }
+    }
+    
+    /// CheckParticipant에서 선택한 selectedUser들의 정보를 currentMoimSchedule에 저장합니다
+    func setSelectedUserListToCurrentMoimSchedule(list: [MoimUser]) {
+        scheduleState.currentMoimSchedule.users = list
+    }
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractorImpl.swift
@@ -12,6 +12,7 @@ struct MoimInteractorImpl: MoimInteractor {
 	@Injected(\.moimRepository) var moimRepository
 	@Injected(\.appState) var appState
 	@Injected(\.moimState) var moimState
+    @Injected(\.scheduleState) var scheduleState
 	
 	// 모임 리스트 가져오기
 	func getGroups() async {
@@ -136,4 +137,89 @@ struct MoimInteractorImpl: MoimInteractor {
 			return schedules.last!.position + 1
 		}
 	}
+    
+    /// scheduleState.currentMoimSchedule의 내용을 추가하여 서버로 전송합니다.
+    func postNewMoimSchedule() async {
+        let temp = scheduleState.currentMoimSchedule
+        print("Current TEMPLATE: \(temp)")
+        
+        let calendar = Calendar.current
+        let startDate = temp.startDate
+        let endDate = temp.endDate
+
+        let interval = calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 0
+        
+        guard let moimId = temp.moimId else {
+            print("moimId Required")
+            return
+        }
+        
+        let postSchedule = postMoimScheduleRequest(
+            moimId: moimId,
+            name: temp.name,
+            startDate: Int(startDate.timeIntervalSince1970),
+            endDate: Int(endDate.timeIntervalSince1970),
+            interval: interval,
+            x: temp.x,
+            y: temp.y,
+            locationName: temp.locationName,
+            Users: temp.users.map{ $0.userId }
+        )
+        
+        let result = await moimRepository.postMoimSchedule(data: postSchedule)
+        print("API 요청 결과 : \(String(describing: result))")
+        
+        // TODO: 해당 부분 그룹 캘린더용으로 업데이트 필요
+//        if result != nil {
+////            await setCalendar(date: startDate) -> 그룹 캘린더 업데이트로 변경 필요
+//            DispatchQueue.main.async {
+//                NotificationCenter.default.post(name: .reloadCalendarViaNetwork, object: nil, userInfo: ["date": temp.startDate.toYMD()])
+//            }
+//        }
+        
+    }
+    
+    /// scheduleState.currentSchedule의 내용을 추가하여 서버로 전송 - 기존 정보를 수정합니다.
+    func patchMoimSchedule() async {
+        let temp = scheduleState.currentMoimSchedule
+        
+        guard let scheduleId = temp.moimScheduleId else {
+            print("ScheduleID not included")
+            return
+        }
+        
+        let calendar = Calendar.current
+        let startDate = temp.startDate
+        let endDate = temp.endDate
+
+        let interval = calendar.dateComponents([.day], from: startDate, to: endDate).day ?? 0
+        
+        let patchSchedule = patchMoimScheduleRequest(
+            moimScheduleId: scheduleId,
+            name: temp.name,
+            startDate: Int(startDate.timeIntervalSince1970),
+            endDate: Int(endDate.timeIntervalSince1970),
+            interval: interval,
+            x: temp.x,
+            y: temp.y,
+            locationName: temp.locationName,
+            Users: temp.users.map { $0.userId }
+        )
+        
+        let result = await moimRepository.patchMoimSchedule(scheduleId: scheduleId, data: patchSchedule)
+        print(String(describing: result))
+    }
+    
+    /// 현재 수정하고 있는 스케쥴을 서버로 삭제 요청합니다.
+    func deleteMoimSchedule() async {
+        let temp = scheduleState.currentMoimSchedule
+        
+        guard let scheduleId = temp.moimScheduleId else {
+            print("ScheduleID not included")
+            return
+        }
+        
+        let result = await moimRepository.deleteMoimSchedule(scheduleId: scheduleId)
+        print(String(describing: result))
+    }
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Moim/MoimEndPoint.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Moim/MoimEndPoint.swift
@@ -15,6 +15,10 @@ enum MoimEndPoint {
 	case participateMoim(groupCode: String)
 	case withdrawMoim(moimId: Int)
 	case getMoimSchedule(moimId: Int)
+    // Schedule
+    case postMoimSchedule(data: postMoimScheduleRequest)
+    case patchMoimSchedule(data: patchMoimScheduleRequest)
+    case deleteMoimSchedule(scheduleId: Int)
 }
 
 extension MoimEndPoint: EndPoint {
@@ -36,6 +40,10 @@ extension MoimEndPoint: EndPoint {
 			return "/withdraw/\(moimId)"
 		case .getMoimSchedule(let moimId):
 			return "/schedule/\(moimId)/all"
+        case .postMoimSchedule, .patchMoimSchedule:
+            return "/schedule"
+        case .deleteMoimSchedule(scheduleId: let scheduleId):
+            return "/\(scheduleId)"
 		}
 	}
 	
@@ -53,7 +61,13 @@ extension MoimEndPoint: EndPoint {
 			return .delete
 		case .getMoimSchedule:
 			return .get
-		}
+        case .postMoimSchedule:
+            return .post
+        case .patchMoimSchedule:
+            return .patch
+        case .deleteMoimSchedule:
+            return .delete
+        }
 	}
 	
 	var task: APITask {
@@ -70,6 +84,12 @@ extension MoimEndPoint: EndPoint {
 			return .requestPlain
 		case .getMoimSchedule:
 			return .requestPlain
+        case .postMoimSchedule(data: let data):
+            return .requestJSONEncodable(parameters: data)
+        case .patchMoimSchedule(data: let data):
+            return .requestJSONEncodable(parameters: data)
+        case .deleteMoimSchedule:
+            return .requestPlain
 		}
 	}
 	

--- a/Namo_SwiftUI/Namo_SwiftUI/Model/DTO/MoimDTO.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Model/DTO/MoimDTO.swift
@@ -101,3 +101,27 @@ extension MoimScheduleDTO {
 		)
 	}
 }
+
+struct postMoimScheduleRequest: Encodable {
+    let moimId: Int
+    let name: String
+    let startDate: Int
+    let endDate: Int
+    let interval: Int
+    let x: Double?
+    let y: Double?
+    let locationName: String
+    let Users: [Int]
+}
+
+struct patchMoimScheduleRequest: Encodable {
+    let moimScheduleId: Int
+    let name: String
+    let startDate: Int
+    let endDate: Int
+    let interval: Int
+    let x: Double?
+    let y: Double?
+    let locationName: String
+    let Users: [Int]
+}

--- a/Namo_SwiftUI/Namo_SwiftUI/Model/MoimScheduleTemplate.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Model/MoimScheduleTemplate.swift
@@ -1,0 +1,51 @@
+//
+//  MoimScheduleTemplate.swift
+//  Namo_SwiftUI
+//
+//  Created by 박민서 on 4/14/24.
+//
+
+
+import Foundation
+
+/// 모임 일정 생성/수정에 사용되는 모델입니다.
+struct MoimScheduleTemplate {
+    /// 모임 ID
+    var moimId: Int?
+    /// 일정 ID
+    var moimScheduleId: Int?
+    /// 일정 이름
+    var name: String
+    /// 시작 날짜-시간
+    var startDate: Date
+    /// 종료 날짜-시간
+    var endDate: Date
+    /// 경도입니다 : longitude
+    var x: Double
+    /// 위도입니다 : latitude
+    var y: Double
+    /// 장소 이름
+    var locationName: String
+    /// 유저 배열
+    var users: [MoimUser]
+    
+    init(
+        moimScheduleId: Int? = nil,
+        name: String? = nil,
+        startDate: Date? = nil,
+        endDate: Date? = nil,
+        x: Double? = nil,
+        y: Double? = nil,
+        locationName: String? = nil,
+        users: [MoimUser]? = nil
+    ) {
+        self.moimScheduleId = moimScheduleId
+        self.name = name ?? ""
+        self.startDate = startDate ?? Date()
+        self.endDate = endDate ?? Date()
+        self.x = x ?? 0.0
+        self.y = y ?? 0.0
+        self.locationName = locationName ?? ""
+        self.users = users ?? []
+    }
+}

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupCalendarView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupCalendarView.swift
@@ -84,12 +84,22 @@ struct GroupCalendarView: View {
 			if showGroupInfo {
 				groupInfo
 			}
+            
+            
+            if isToDoSheetPresented {
+                Color.black.opacity(0.3)
+                    .ignoresSafeArea(.all, edges: .all)
+            }
 		}
 		.ignoresSafeArea(edges: .bottom)
 		.toolbar(.hidden, for: .navigationBar)
 		.onAppear {
 			groupName = moimState.currentMoim.groupName ?? ""
 		}
+        .fullScreenCover(isPresented: $isToDoSheetPresented, content: {
+            GroupToDoEditView()
+                .background(ClearBackground())
+        })
     }
 	
 	private var header: some View {
@@ -221,7 +231,9 @@ struct GroupCalendarView: View {
 		.frame(width: screenWidth, height: screenHeight * 0.47)
 		.background(Color.white)
 		.overlay(alignment: .bottomTrailing) {
-			Button(action: {}, label: {
+			Button(action: {
+                self.isToDoSheetPresented = true
+            }, label: {
 				Image(.floatingAdd)
 					.padding(.bottom, 37)
 					.padding(.trailing, 25)

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupToDo/GroupToDoEditView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupToDo/GroupToDoEditView.swift
@@ -18,6 +18,7 @@ struct GroupToDoEditView: View {
     @EnvironmentObject var moimState: MoimState
     @Injected(\.scheduleInteractor) var scheduleInteractor
     @Injected(\.placeInteractor) var placeInteractor
+    @Injected(\.moimInteractor) var moimInteractor
     
     /// 시작 날짜 + 시각 Picker Show value
     @State private var showStartTimePicker: Bool = false
@@ -179,9 +180,9 @@ struct GroupToDoEditView: View {
                                 Task {
                                     
                                     if self.isRevise {
-                                        await scheduleInteractor.patchMoimSchedule()
+                                        await moimInteractor.patchMoimSchedule()
                                     } else {
-                                        await scheduleInteractor.postNewMoimSchedule()
+                                        await moimInteractor.postNewMoimSchedule()
                                     }
                                     // 닫기
                                     dismissThis()
@@ -234,7 +235,7 @@ struct GroupToDoEditView: View {
                         Task {
                             // 삭제 후 dismiss
 //                            await self.scheduleInteractor.deleteSchedule()
-                            await self.scheduleInteractor.deleteMoimSchedule()
+                            await self.moimInteractor.deleteMoimSchedule()
 //                            dismissThis()
                         }
                     }
@@ -325,6 +326,7 @@ struct GroupToDoEditView: View {
         
         @EnvironmentObject var moimState: MoimState
         @Injected(\.scheduleInteractor) var scheduleInteractor
+        @Injected(\.moimInteractor) var moimInteractor
         
         @Binding var showCheckParticipant: Bool
         @State var selectedUser: [MoimUser] = []
@@ -337,7 +339,7 @@ struct GroupToDoEditView: View {
                 leftButtonAction: {},
                 rightButtonTitle: "저장",
                 rightButtonAction: {
-                    scheduleInteractor.setSelectedUserListToCurrentMoimSchedule(list: selectedUser)
+                    moimInteractor.setSelectedUserListToCurrentMoimSchedule(list: selectedUser)
                     return true
                 },
                 content: AnyView(

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupToDo/GroupToDoEditView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupToDo/GroupToDoEditView.swift
@@ -1,0 +1,399 @@
+//
+//  GroupToDoEditView.swift
+//  Namo_SwiftUI
+//
+//  Created by 박민서 on 4/14/24.
+//
+
+
+import SwiftUI
+import Factory
+
+/// 일정 추가/생성/삭제에서 표시되는 Edit 화면 입니다.
+/// 장소 선택 시 -> ToDoSelectPlaceView
+struct GroupToDoEditView: View {
+    
+    @EnvironmentObject var appState: AppState
+    @EnvironmentObject var scheduleState: ScheduleState
+    @EnvironmentObject var moimState: MoimState
+    @Injected(\.scheduleInteractor) var scheduleInteractor
+    @Injected(\.placeInteractor) var placeInteractor
+    
+    /// 시작 날짜 + 시각 Picker Show value
+    @State private var showStartTimePicker: Bool = false
+    /// 종료 날짜 + 시각 Picker Show value
+    @State private var showEndTimePicker: Bool = false
+    /// KakaoMapView draw State
+    @State var draw: Bool = false
+    /// 수정 화면일때 화면 변경 State
+    @State var isRevise: Bool = false
+    /// 현재 화면 dismiss
+    @Environment(\.dismiss) private var dismiss
+    /// ToDoSelectPlaceView Show State
+    @State var isShowSheet: Bool = false
+    /// 삭제 Alert Show State
+    @State var showAlert: Bool = false
+    /// 참석자 선택 창 Show State
+    @State var showCheckParticipant: Bool = false
+
+    /// 날짜 포매터
+    private let dateFormatter = DateFormatter()
+    
+    init() {
+        // SwiftUI의 NavigationTitle는 Font가 적용되지 않습니다.
+        UINavigationBar.appearance().titleTextAttributes = [.font : UIFont(name: "Pretendard-Bold", size: 15)!]
+        UINavigationBar.appearance().barTintColor = .white
+        self.dateFormatter.dateFormat = "yyyy.MM.dd (E) hh:mm a"
+    }
+    
+    
+    
+    var body: some View {
+        
+        ZStack(alignment: .top) {
+            // MARK: 상단 삭제 원형 버튼
+            if isRevise {
+                DeleteButton(image: "ic_delete_schedule", frame: 30) {
+                    self.showAlert = true
+                }
+            }
+            
+            // MARK: 메인 시트
+            NavigationStack {
+                ScrollView {
+                    VStack {
+                        // MARK: 일정 제목
+                        TextField("일정 이름", text: $scheduleState.currentMoimSchedule.name)
+                            .font(.pretendard(.bold, size: 22))
+                            .padding(EdgeInsets(top: 18, leading: 30, bottom: 15, trailing: 30))
+                        
+                        // MARK: 일정 선택내용 아이템 목록
+                        VStack(alignment: .center, spacing: 20) {
+                            ListItem(listTitle: "참석자") {
+                                Button {
+                                    self.showCheckParticipant = true
+                                } label: {
+                                    HStack {
+                                        Text(usersInString(scheduleState.currentMoimSchedule.users))
+                                            .font(.pretendard(.regular, size: 15))
+                                            .foregroundStyle(.mainText)
+                                        
+                                        Image("vector3")
+                                            .renderingMode(.template)
+                                            .foregroundStyle(.mainText)
+                                        
+                                    }
+                                    .lineSpacing(12)
+                                }
+                            }
+                            .padding(.vertical, 14)
+                            
+                            ListItem(listTitle: "시작") {
+                                Text(dateFormatter.string(from: scheduleState.currentMoimSchedule.startDate))
+                                    .font(.pretendard(.regular, size: 15))
+                                    .foregroundStyle(.mainText)
+                                    .onTapGesture {
+                                        withAnimation(.easeInOut(duration: 0.3)) {
+                                            self.showStartTimePicker.toggle()
+                                        }
+                                    }
+                            }
+                            
+                            if (showStartTimePicker) {
+                                DatePicker("StartTimePicker", selection: $scheduleState.currentMoimSchedule.startDate)
+                                    .datePickerStyle(.graphical)
+                                    .labelsHidden()
+                                    .tint(.mainOrange)
+                            }
+                            
+                            ListItem(listTitle: "종료") {
+                                Text(dateFormatter.string(from: scheduleState.currentMoimSchedule.endDate))
+                                    .font(.pretendard(.regular, size: 15))
+                                    .foregroundStyle(.mainText)
+                                    .onTapGesture {
+                                        withAnimation(.easeInOut(duration: 0.3)) {
+                                            self.showEndTimePicker.toggle()
+                                        }
+                                    }
+                            }
+                            
+                            if (showEndTimePicker) {
+                                DatePicker("EndTimePicker", selection: $scheduleState.currentMoimSchedule.endDate, in: scheduleState.currentMoimSchedule.startDate...)
+                                    .datePickerStyle(.graphical)
+                                    .labelsHidden()
+                                    .tint(.mainOrange)
+                            }
+                            
+                            ListItem(listTitle: "장소") {
+                                Button(action: {
+                                    self.draw = false
+                                    withAnimation {
+                                        isShowSheet = true
+                                    }
+                                }, label: {
+                                    HStack {
+                                        Text(scheduleState.currentMoimSchedule.locationName.isEmpty ? "위치명" : scheduleState.currentMoimSchedule.locationName)
+                                            .font(.pretendard(.regular, size: 15))
+                                            .foregroundStyle(.mainText)
+                                        Image("vector3")
+                                            .renderingMode(.template)
+                                            .foregroundStyle(.mainText)
+                                    }
+                                    .lineSpacing(12)
+                                })
+                            }
+                            .padding(.vertical, 14)
+                        }
+                        .padding(.horizontal, 30)
+                        
+                        // MARK: 카카오 맵 뷰
+                        KakaoMapView(draw: $draw, pinList: $appState.placeState.placeList, selectedPlace: $appState.placeState.selectedPlace)
+                            .onAppear(perform: {
+                                self.draw = true
+                            }).onDisappear(perform: {
+                                self.draw = false
+                            })
+                            .frame(width: 330, height:200)
+                            .border(Color.init(hex: 0xD9D9D9), width: 1)
+             
+                        Spacer()
+                    }
+                    .navigationTitle(self.isRevise ? "일정 편집" : "새 일정")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .navigationBarBackButtonHidden(true)
+                    .toolbar {
+                        ToolbarItem(placement: .topBarLeading) {
+                            Button(action: {
+                                // 닫기
+                                dismissThis()
+                            }, label: {
+                                Text("닫기")
+                                    .font(.pretendard(.regular, size: 15))
+                            })
+                            .foregroundStyle(.mainText)
+                        }
+                        
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button(action: {
+                                // 저장
+                                Task {
+                                    
+                                    if self.isRevise {
+                                        await scheduleInteractor.patchMoimSchedule()
+                                    } else {
+                                        await scheduleInteractor.postNewMoimSchedule()
+                                    }
+                                    // 닫기
+                                    dismissThis()
+                                }
+                                
+                            }, label: {
+                                Text("저장")
+                                    .font(.pretendard(.regular, size: 15))
+                            })
+                            .foregroundStyle(.mainText)
+                        }
+                    }//: VStack - toolbar
+                }//: ScrollView
+                .background(.white)
+            }
+            
+            .clipShape(UnevenRoundedRectangle(cornerRadii: .init(
+                topLeading: 15,
+                topTrailing: 15)))
+            .shadow(radius: 10)
+            .offset(y: 100)
+            
+            
+            // MARK: 삭제 Alert 창
+            if showAlert {
+                NamoAlertView(
+                    showAlert: $showAlert,
+                    content: AnyView(
+                        VStack {
+                            Text("모임 일정을 정말 삭제하시겠어요?")
+                                .font(.pretendard(.bold, size: 18))
+                                .foregroundStyle(.mainText)
+                                .multilineTextAlignment(.center)
+                                .padding(.top, 24)
+                                .padding(.bottom, 8)
+                            Text("삭제한 모임 일정은\n모든 참여자의 일정에서 삭제됩니다.")
+                                .font(.pretendard(.regular, size: 14))
+                                .foregroundStyle(.mainText)
+                                .lineLimit(2)
+                                .multilineTextAlignment(.center)
+                        }
+                            .frame(minHeight:114)
+                    ),
+                    leftButtonTitle: "취소",
+                    leftButtonAction: {
+                        // 자동 Alert창 dismiss
+                    },
+                    rightButtonTitle: "삭제",
+                    rightButtonAction: {
+                        Task {
+                            // 삭제 후 dismiss
+//                            await self.scheduleInteractor.deleteSchedule()
+                            await self.scheduleInteractor.deleteMoimSchedule()
+//                            dismissThis()
+                        }
+                    }
+                )
+            }
+            
+            // MARK: 참석자 선택 창
+            if showCheckParticipant {
+                CheckParticipant(
+                    showCheckParticipant: $showCheckParticipant
+                )
+            }
+            
+        }
+        .overlay(isShowSheet ? ToDoSelectPlaceView(isShowSheet: $isShowSheet, preMapDraw: $draw, isGroup: true) : nil)
+        .ignoresSafeArea(.all, edges: .bottom)
+        .onAppear(perform: {
+            // 템플릿에 모임Id 주입
+            self.scheduleState.currentMoimSchedule.moimId = self.moimState.currentMoim.groupId
+            print("현재 템플릿의 moimID : \(self.scheduleState.currentMoimSchedule.moimId)")
+            // 밖에서 주입 받은 스케쥴 == 스케쥴 수정일 때
+            if self.scheduleState.currentMoimSchedule.moimScheduleId != nil {
+                self.isRevise = true
+            }
+            // 현재 장소 리스트에 Schedule의 장소를 추가
+            // 임시용으로, placeID가 추가된 후 추후에 수정이 필요합니다.
+            if self.isRevise {
+                let temp = self.scheduleState.currentMoimSchedule
+                placeInteractor.appendPlaceList(place: Place(
+                    id: 0,
+                    x: temp.x,
+                    y: temp.y,
+                    name: temp.locationName,
+                    address: "임시용입니다",
+                    rodeAddress: "임시용입니다")
+                )
+            }
+        })
+    }
+    
+    /// 현재 ToDoEditView를 종로하고, Temp와 PlaceList를 clear합니다.
+    private func dismissThis() {
+        self.scheduleState.currentMoimSchedule = MoimScheduleTemplate()
+        // 대충 여기 모임 스케쥴 템플릿 초기화
+        placeInteractor.clearPlaces(isSave: false)
+        placeInteractor.selectPlace(place: nil)
+        dismiss()
+    }
+    
+    /// 일정 생성/수정 화면의 각 아이템 리스트 아이템 뷰입니다.
+    private struct ListItem<Content: View>: View {
+        
+        var listTitle: String
+        var content: () -> Content
+        
+        var body: some View {
+            HStack {
+                Text(listTitle)
+                    .font(.pretendard(.bold, size: 15))
+                Spacer()
+                content()
+            }
+        }
+    }
+    
+    struct DeleteButton: View {
+        
+        let image: String
+        let frame: CGFloat
+        let action: () -> Void
+        
+        var body: some View {
+            
+            CircleItemView(content: {
+                Image(image)
+                    .resizable()
+                    .frame(width: frame, height: frame)
+            })
+            .offset(y: 50)
+            .onTapGesture(perform: {
+                action()
+            })
+        }
+    }
+    
+    /// 참석자 선택 리스트 뷰입니다.
+    struct CheckParticipant: View {
+        
+        @EnvironmentObject var moimState: MoimState
+        @Injected(\.scheduleInteractor) var scheduleInteractor
+        
+        @Binding var showCheckParticipant: Bool
+        @State var selectedUser: [MoimUser] = []
+        
+        var body: some View {
+            NamoAlertViewWithTopButton(
+                showAlert: $showCheckParticipant,
+                title: "참석자",
+                leftButtonTitle: "닫기",
+                leftButtonAction: {},
+                rightButtonTitle: "저장",
+                rightButtonAction: {
+                    scheduleInteractor.setSelectedUserListToCurrentMoimSchedule(list: selectedUser)
+                    return true
+                },
+                content: AnyView(
+                    ScrollView{
+                        VStack(spacing: 15) {
+                            ForEach(moimState.currentMoim.moimUsers, id: \.userId) { user in
+                                HStack(spacing: 20) {
+                                    Button(
+                                        action: {
+                                            if selectedUser.contains(where: {$0 == user}) {
+                                                selectedUser.removeAll(where: {$0 == user})
+                                            } else {
+                                                selectedUser.append(user)
+                                            }
+                                        }, label: {
+                                            Image(selectedUser.contains(where: {$0 == user}) ? .isSelectedTrue : .isSelectedFalse)
+                                                .resizable()
+                                                .frame(width: 20, height: 20)
+                                        }
+                                    )
+                                    
+                                    Text(user.userName)
+                                    Spacer()
+                                }
+                            }
+                        }
+                        
+                    }
+                        .frame(height: 265)
+                        .padding(.top, 25)
+                )
+            )
+        }
+        
+       
+    }
+    
+    /// 유저 리스트 값을 문자열로 반환해주는 함수 입니다.
+    private func usersInString(_ users: [MoimUser]) -> String {
+        guard users.count > 0 else { return "없음" }
+         
+        var userNames = users.count > 4
+        ? users[0...3].reduce(into: "") { $0 += $1.userName + ", " }
+        : users.reduce(into: "") { $0 += $1.userName + ", " }
+        userNames = String(userNames.dropLast(2))
+        
+        let printString = users.count > 4
+        ? userNames + " 외 \(users.count-4)명"
+        : userNames
+        
+        return printString
+    }
+}
+
+//#Preview {
+//    GroupToDoEditView()
+//        .environmentObject(AppState())
+//}
+

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/CalendarScheduleDetailItem.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/CalendarScheduleDetailItem.swift
@@ -39,7 +39,10 @@ struct CalendarScheduleDetailItem: View {
 				
 				Spacer()
 				
-				Button(action: {}, label: {
+				Button(action: {
+                    scheduleInteractor.setScheduleToCurrentSchedule(schedule: self.schedule)
+                    self.isToDoSheetPresented = true
+                }, label: {
 					Image(schedule.hasDiary ? .btnAddRecordOrange : .btnAddRecord)
 						.resizable()
 						.frame(width: 34, height: 34)
@@ -64,6 +67,7 @@ struct CalendarMoimScheduleDetailItem: View {
 	
 	@Injected(\.scheduleInteractor) var scheduleInteractor
 	@Injected(\.categoryInteractor) var categoryInteractor
+    @Injected(\.moimInteractor) var moimInteractor
 	
 	@Binding var isToDoSheetPresented: Bool
 	
@@ -89,7 +93,10 @@ struct CalendarMoimScheduleDetailItem: View {
 			Spacer()
 			
 			if schedule.curMoimSchedule {
-				Button(action: {}, label: {
+				Button(action: {
+                    moimInteractor.setScheduleToCurrentMoimSchedule(schedule: self.schedule)
+                    self.isToDoSheetPresented = true
+                }, label: {
 					Image(schedule.hasDiaryPlace ? .btnAddRecordOrange : .btnAddRecord)
 						.resizable()
 						.frame(width: 34, height: 34)

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoEditView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoEditView.swift
@@ -119,16 +119,9 @@ struct ToDoEditView: View {
                                     
                                 } label: {
                                     HStack {
-//<<<<<<< HEAD
-//                                        
-//                                        ColorCircleView(color: categoryInteractor.getColorWithPaletteId(id: appState.categoryState.categoryList.first(where: {$0.categoryId == appState.scheduleState.scheduleTemp.categoryId})?.paletteId ?? -1))
-//                                                                                    .frame(width: 13, height: 13)
-//                                        Text(appState.categoryState.categoryList.first(where: {$0.categoryId == appState.scheduleState.scheduleTemp.categoryId})?.name ?? "카테고리 없음")
-//=======
                                         ColorCircleView(color: categoryInteractor.getColorWithPaletteId(id: appState.categoryState.categoryList.first(where: {$0.categoryId == scheduleState.currentSchedule.categoryId})?.paletteId ?? -1))
                                             .frame(width: 13, height: 13)
                                         Text(appState.categoryState.categoryList.first(where: {$0.categoryId == scheduleState.currentSchedule.categoryId})?.name ?? "카테고리 없음")
-//>>>>>>> develop
                                             .font(.pretendard(.regular, size: 15))
                                             .foregroundStyle(.mainText)
                                         
@@ -395,7 +388,7 @@ struct ToDoEditView: View {
                 )
             }
         }
-        .overlay(isShowSheet ? ToDoSelectPlaceView(isShowSheet: $isShowSheet, preMapDraw: $draw) : nil)
+        .overlay(isShowSheet ? ToDoSelectPlaceView(isShowSheet: $isShowSheet, preMapDraw: $draw, isGroup: false) : nil)
         .ignoresSafeArea(.all, edges: .bottom)
         .onAppear(perform: {
             // 밖에서 주입 받은 스케쥴 == 스케쥴 수정일 때

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoSelectPlaceView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoSelectPlaceView.swift
@@ -63,12 +63,8 @@ struct ToDoSelectPlaceView: View {
                         
                         Spacer()
                         Button(action: {
-                            if self.isGroup {
-                                moimInteractor.setPlaceToCurrentMoimSchedule()
-                            } else {
-                                scheduleInteractor.setPlaceToCurrentSchedule()
-                            }
                             placeInteractor.selectPlace(place: nil)
+                            self.dismissThis()
                         }) {
                             Text("취소")
                                 .font(.pretendard(.bold, size: 15))
@@ -85,7 +81,12 @@ struct ToDoSelectPlaceView: View {
                         }
                         Spacer(minLength: 20)
                         Button(action: {
-                            scheduleInteractor.setPlaceToCurrentSchedule()
+                            if self.isGroup {
+                                print("모임에 잘 저장")
+                                moimInteractor.setPlaceToCurrentMoimSchedule()
+                            } else {
+                                scheduleInteractor.setPlaceToCurrentSchedule()
+                            }
                             placeInteractor.clearPlaces(isSave: true)
                             self.dismissThis()
                         }) {

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoSelectPlaceView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoSelectPlaceView.swift
@@ -13,6 +13,7 @@ struct ToDoSelectPlaceView: View {
     @EnvironmentObject var appState: AppState
     @Injected(\.placeInteractor) var placeInteractor
     @Injected(\.scheduleInteractor) var scheduleInteractor
+    @Injected(\.moimInteractor) var moimInteractor
     
     /// 본 화면의 표시 여부 state
     @Binding var isShowSheet: Bool
@@ -25,6 +26,8 @@ struct ToDoSelectPlaceView: View {
     @State var searchText: String = ""
     /// 취소/확인 버튼 show state
     @State var showBtns: Bool = false
+    /// 장소 선택 창이 모임 일정용인지
+    let isGroup: Bool
     
     
     var body: some View {
@@ -60,6 +63,11 @@ struct ToDoSelectPlaceView: View {
                         
                         Spacer()
                         Button(action: {
+                            if self.isGroup {
+                                moimInteractor.setPlaceToCurrentMoimSchedule()
+                            } else {
+                                scheduleInteractor.setPlaceToCurrentSchedule()
+                            }
                             placeInteractor.selectPlace(place: nil)
                         }) {
                             Text("취소")

--- a/Namo_SwiftUI/Namo_SwiftUI/Repository/Moim/MoimRepository.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Repository/Moim/MoimRepository.swift
@@ -14,4 +14,7 @@ protocol MoimRepository {
 	func participateMoim(groupCode: String) async -> Bool
 	func withdrawMoim(moimId: Int) async -> Bool
 	func getMoimSchedule(moimId: Int) async -> getMoimScheduleResponse?
+    func postMoimSchedule(data: postMoimScheduleRequest) async -> Int?
+    func patchMoimSchedule(scheduleId: Int, data: patchMoimScheduleRequest) async -> String?
+    func deleteMoimSchedule(scheduleId: Int) async -> String?
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Repository/Moim/MoimRepositoryImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Repository/Moim/MoimRepositoryImpl.swift
@@ -39,5 +39,15 @@ final class MoimRepositoryImpl: MoimRepository {
 		return await APIManager.shared.performRequest(endPoint: MoimEndPoint.getMoimSchedule(moimId: moimId))
 	}
 	
-	
+    func postMoimSchedule(data: postMoimScheduleRequest) async -> Int? {
+        return await APIManager.shared.performRequest(endPoint: MoimEndPoint.postMoimSchedule(data: data))
+    }
+    
+    func patchMoimSchedule(scheduleId: Int, data: patchMoimScheduleRequest) async -> String? {
+        return await APIManager.shared.performRequest(endPoint: MoimEndPoint.patchMoimSchedule(data: data))
+    }
+    
+    func deleteMoimSchedule(scheduleId: Int) async -> String? {
+        return await APIManager.shared.performRequest(endPoint: MoimEndPoint.deleteMoimSchedule(scheduleId: scheduleId))
+    }
 }


### PR DESCRIPTION
## **Related Issue**
> 연관된 이슈번호를 작성해주세요 
> #54 

## **Description**
> 그룹 모임 일정 생성 추가 화면을 작성했습니다

그룹 캘린더에서 진입(플로우는 개인 캘린더의 진입 방식과 동일합니다.) ->
- `+` 버튼으로 생성 화면에 진입하고
- 연필(수정) 버튼으로 수정 화면에 진입합니다.

### **Screenshot (Optional)**
![Simulator Screen Recording - iPhone 15 Pro - 2024-04-14 at 01 48 00](https://github.com/Namo-Mongmong/iOS_SwiftUI/assets/125115284/611c7400-7296-436e-8265-b7b4f6e023d4)

## **Requirements for Review**
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

❗️ endpoint부터 작성한 결과, moimSchedule이 moim 도메인에 포함되도록 작성했습니다.
❗️이는 ScheduleInteractor와 MoimInteractor를 병용하는 문제를 발생시키고 있습니다.
❗️추후 리팩토링때 MoimSchedule을 어떻게 관리 + 개인 Schedule과는 어떻게 분리할 것인지에 대해 논의해야합니다.

❗️❗️ 해당 화면에서 저장/수정 API 콜 시 에러로그 표출과 함께 API 요청이 전송되지 않는 오류가 있습니다.
❗️❗️ 모두의 도움이 필요합니다..!!!
