### PR TITLE
[FIX] 카카오맵 버전 업데이트 대응

### DIFF
--- a/Namo_SwiftUI/Namo_SwiftUI.xcodeproj/project.pbxproj
+++ b/Namo_SwiftUI/Namo_SwiftUI.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		2C5717E62B61306700B0F3B3 /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5717E52B61306700B0F3B3 /* Date+.swift */; };
 		2C5717EA2B67A80000B0F3B3 /* RoundedCorners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C5717E92B67A80000B0F3B3 /* RoundedCorners.swift */; };
 		2C7232352B6DFEEF0097D669 /* ScheduleInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7232342B6DFEEF0097D669 /* ScheduleInteractor.swift */; };
+		2C80ECD72BD572C1002F38A7 /* KakaoMapsSDK-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 2C80ECD62BD572C1002F38A7 /* KakaoMapsSDK-SPM */; };
 		2CF445042B760A8100A8E514 /* NamoAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF445032B760A8100A8E514 /* NamoAlertView.swift */; };
 		2CF445082B78E22900A8E514 /* CategoryEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF445072B78E22900A8E514 /* CategoryEndPoint.swift */; };
 		2CF4450A2B78E3C700A8E514 /* CategoryDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CF445092B78E3C700A8E514 /* CategoryDTO.swift */; };
@@ -102,7 +103,6 @@
 		50E6E5492B89FC5F006CB20D /* SettingComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E6E5482B89FC5F006CB20D /* SettingComponent.swift */; };
 		50F8F9032B89D95B0037577C /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F8F9022B89D95B0037577C /* SettingView.swift */; };
 		8834ADEB2B67BEBE0024F724 /* naveridlogin-ios-sp in Frameworks */ = {isa = PBXBuildFile; productRef = 8834ADEA2B67BEBE0024F724 /* naveridlogin-ios-sp */; };
-		8834ADEE2B67BF430024F724 /* KakaoMapsSDK_SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 8834ADED2B67BF430024F724 /* KakaoMapsSDK_SPM */; };
 		8834ADF12B67BFFC0024F724 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 8834ADF02B67BFFC0024F724 /* KakaoSDK */; };
 		8834ADF32B67BFFC0024F724 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 8834ADF22B67BFFC0024F724 /* KakaoSDKAuth */; };
 		8834ADF52B67BFFC0024F724 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 8834ADF42B67BFFC0024F724 /* KakaoSDKCommon */; };
@@ -325,11 +325,11 @@
 			files = (
 				5012A9D62B59389F00544AB0 /* RealmSwift in Frameworks */,
 				8834ADF12B67BFFC0024F724 /* KakaoSDK in Frameworks */,
-				8834ADEE2B67BF430024F724 /* KakaoMapsSDK_SPM in Frameworks */,
 				5012A9D42B59389F00544AB0 /* Realm in Frameworks */,
 				8834ADF52B67BFFC0024F724 /* KakaoSDKCommon in Frameworks */,
 				5012A9CE2B59382200544AB0 /* Alamofire in Frameworks */,
 				5012A9D12B59382F00544AB0 /* Factory in Frameworks */,
+				2C80ECD72BD572C1002F38A7 /* KakaoMapsSDK-SPM in Frameworks */,
 				8834ADF32B67BFFC0024F724 /* KakaoSDKAuth in Frameworks */,
 				8834ADF72B67BFFC0024F724 /* KakaoSDKUser in Frameworks */,
 				2C57177E2B5BE9E800B0F3B3 /* SwiftUICalendar in Frameworks */,
@@ -1041,11 +1041,11 @@
 				508EC7B42B5A76C5006E5EEA /* Lottie */,
 				2C57177D2B5BE9E800B0F3B3 /* SwiftUICalendar */,
 				8834ADEA2B67BEBE0024F724 /* naveridlogin-ios-sp */,
-				8834ADED2B67BF430024F724 /* KakaoMapsSDK_SPM */,
 				8834ADF02B67BFFC0024F724 /* KakaoSDK */,
 				8834ADF22B67BFFC0024F724 /* KakaoSDKAuth */,
 				8834ADF42B67BFFC0024F724 /* KakaoSDKCommon */,
 				8834ADF62B67BFFC0024F724 /* KakaoSDKUser */,
+				2C80ECD62BD572C1002F38A7 /* KakaoMapsSDK-SPM */,
 			);
 			productName = Namo_SwiftUI;
 			productReference = 5012A9BB2B5933CB00544AB0 /* Namo_SwiftUI.app */;
@@ -1563,6 +1563,11 @@
 			package = 2C57177C2B5BE9E800B0F3B3 /* XCRemoteSwiftPackageReference "SwiftUICalendar" */;
 			productName = SwiftUICalendar;
 		};
+		2C80ECD62BD572C1002F38A7 /* KakaoMapsSDK-SPM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8834ADEC2B67BF430024F724 /* XCRemoteSwiftPackageReference "KakaoMapsSDK-SPM" */;
+			productName = "KakaoMapsSDK-SPM";
+		};
 		5012A9CD2B59382200544AB0 /* Alamofire */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5012A9CC2B59382200544AB0 /* XCRemoteSwiftPackageReference "Alamofire" */;
@@ -1597,11 +1602,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8834ADE92B67BEBE0024F724 /* XCRemoteSwiftPackageReference "naveridlogin-ios-sp" */;
 			productName = "naveridlogin-ios-sp";
-		};
-		8834ADED2B67BF430024F724 /* KakaoMapsSDK_SPM */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 8834ADEC2B67BF430024F724 /* XCRemoteSwiftPackageReference "KakaoMapsSDK-SPM" */;
-			productName = KakaoMapsSDK_SPM;
 		};
 		8834ADF02B67BFFC0024F724 /* KakaoSDK */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Namo_SwiftUI/Namo_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Namo_SwiftUI/Namo_SwiftUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "9e6bc30675b5a733fff5aae48003a01db68ecc4afbf84ff750213f4fa8ed3588",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -32,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao-mapsSDK/KakaoMapsSDK-SPM.git",
       "state" : {
-        "revision" : "d2b50b7ae9785f16287df49aa2d010c8e00cf6ee",
-        "version" : "2.6.3"
+        "revision" : "c1571d411caca22ad6e3e76a593e0b95b3586fb7",
+        "version" : "2.10.4"
       }
     },
     {
@@ -91,5 +92,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
## **Related Issue**
- #65 
## **Description**
- 카카오 맵 인가 방식 변경 REST API Key -> Native APP Key
- 카카오 맵 버전 업데이트에 따른 명칭들 변경
  -  initEngine() -> prepareEngine()
  - startEngine(), startRendering() -> activateEngine()
  - stopEngine(), stopRendering() -> pauseEngine()
 - deinit 시 map 초기화
 - addView 후 기존 Result.OK -> addViewSucceeded(), addViewFailed() delegate 함수로 변경
