### PR TITLE
[Feat] 일정 QA 2차 반영

### DIFF
--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Place/PlaceInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Place/PlaceInteractor.swift
@@ -6,7 +6,8 @@
 //
 
 protocol PlaceInteractor {
-    func getPlaceList(query: String) async 
+    func fetchPlaceList(query: String) async 
+    func getPlaceList(query: String) async -> [Place]?
     func selectPlace(place: Place?)
     func clearPlaces(isSave: Bool)
     func appendPlaceList(place: Place)

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Place/PlaceInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Place/PlaceInteractorImpl.swift
@@ -14,11 +14,17 @@ struct PlaceInteractorImpl: PlaceInteractor {
     @Injected(\.placeRepository) private var placeRepository
     
     /// KakaoMapAPI를 통해 해당 쿼리에 맞는 결과를 placeList에 페칭합니다.
-    func getPlaceList(query: String) async {
+    func fetchPlaceList(query: String) async {
         let result = await placeRepository.getKakaoMapPlaces(query: query)
         DispatchQueue.main.async {
             appState.placeState.placeList = result?.documents.map { $0.toPlace() } ?? []
         }
+    }
+    
+    /// KakaoMapAPI를 통해 해당 쿼리에 맞는 결과를 list로 반환합니다.
+    func getPlaceList(query: String) async -> [Place]?  {
+        let result = await placeRepository.getKakaoMapPlaces(query: query)
+        return result?.documents.map { $0.toPlace() }
     }
     
     /// placeState의 selectPlace를 새로운 place로 변경합니다.

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractor.swift
@@ -34,4 +34,5 @@ protocol ScheduleInteractor {
     func setScheduleToCurrentSchedule(schedule: Schedule?)
 	func yearMonthBetween(start: Date, end: Date) -> [YearMonth]
     func setDateAndTimesToCurrentSchedule(focusDate: YearMonthDay?)
+    func setDateAndTimesToCurrentMoimSchedule(focusDate: YearMonthDay?)
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractor.swift
@@ -33,4 +33,5 @@ protocol ScheduleInteractor {
     func deleteSchedule() async
     func setScheduleToCurrentSchedule(schedule: Schedule?)
 	func yearMonthBetween(start: Date, end: Date) -> [YearMonth]
+    func setDateAndTimesToCurrentSchedule(focusDate: YearMonthDay?)
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractorImpl.swift
@@ -355,7 +355,7 @@ struct ScheduleInteractorImpl: ScheduleInteractor {
 		return result
 	}
     
-    /// 현재 focusDate를 추가하는 일정 템플릿의 날짜로 설정합니다
+    /// 현재 focusDate를 추가하는 개인 일정 템플릿의 날짜로 설정합니다
     func setDateAndTimesToCurrentSchedule(focusDate: YearMonthDay?) {
         if let focusDate = focusDate?.toDate() {
             let calendar = Calendar.current
@@ -368,6 +368,23 @@ struct ScheduleInteractorImpl: ScheduleInteractor {
             let endDate = calendar.date(from: dateComponents)
             scheduleState.currentSchedule.startDate = startDate ?? focusDate
             scheduleState.currentSchedule.endDate = endDate ?? focusDate
+        }
+    }
+    
+    
+    /// 현재 focusDate를 추가하는 모임 일정 템플릿의 날짜로 설정합니다
+    func setDateAndTimesToCurrentMoimSchedule(focusDate: YearMonthDay?) {
+        if let focusDate = focusDate?.toDate() {
+            let calendar = Calendar.current
+            var dateComponents = calendar.dateComponents([.year, .month, .day], from: focusDate)
+            
+            dateComponents.hour = 8
+            let startDate = calendar.date(from: dateComponents)
+            
+            dateComponents.hour = 9
+            let endDate = calendar.date(from: dateComponents)
+            scheduleState.currentMoimSchedule.startDate = startDate ?? focusDate
+            scheduleState.currentMoimSchedule.endDate = endDate ?? focusDate
         }
     }
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractorImpl.swift
@@ -354,4 +354,20 @@ struct ScheduleInteractorImpl: ScheduleInteractor {
 		
 		return result
 	}
+    
+    /// 현재 focusDate를 추가하는 일정 템플릿의 날짜로 설정합니다
+    func setDateAndTimesToCurrentSchedule(focusDate: YearMonthDay?) {
+        if let focusDate = focusDate?.toDate() {
+            let calendar = Calendar.current
+            var dateComponents = calendar.dateComponents([.year, .month, .day], from: focusDate)
+            
+            dateComponents.hour = 8
+            let startDate = calendar.date(from: dateComponents)
+            
+            dateComponents.hour = 9
+            let endDate = calendar.date(from: dateComponents)
+            scheduleState.currentSchedule.startDate = startDate ?? focusDate
+            scheduleState.currentSchedule.endDate = endDate ?? focusDate
+        }
+    }
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Model/DTO/ScheduleDTO.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Model/DTO/ScheduleDTO.swift
@@ -34,7 +34,8 @@ struct ScheduleDTO: Codable {
 	let interval: Int
 	let x: Double?
 	let y: Double?
-	let locationName: String
+	let locationName: String?
+    let kakaoLocationId: Int?
 	let categoryId: Int
 	let hasDiary: Bool?
 	let moimSchedule: Bool
@@ -51,7 +52,7 @@ extension ScheduleDTO {
 			interval: interval,
 			x: x,
 			y: y,
-			locationName: locationName,
+            locationName: locationName ?? "",
 			categoryId: categoryId,
 			hasDiary: hasDiary,
 			moimSchedule: moimSchedule

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupCalendarView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupCalendarView.swift
@@ -260,6 +260,7 @@ struct GroupCalendarView: View {
 		.background(Color.white)
 		.overlay(alignment: .bottomTrailing) {
 			Button(action: {
+                scheduleInteractor.setDateAndTimesToCurrentMoimSchedule(focusDate: focusDate)
                 self.isToDoSheetPresented = true
             }, label: {
 				Image(.floatingAdd)

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/HomeMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/HomeMainView.swift
@@ -251,6 +251,7 @@ struct HomeMainView: View {
 		.background(Color.white)
 		.overlay(alignment: .bottomTrailing) {
 			Button(action: {
+                scheduleInteractor.setDateAndTimesToCurrentSchedule(focusDate: focusDate)
                 self.isToDoSheetPresented = true
             }, label: {
 				Image(.floatingAdd)

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoEditView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoEditView.swift
@@ -415,15 +415,14 @@ struct ToDoEditView: View {
             // 현재 장소 리스트에 Schedule의 장소를 추가
             // 임시용으로, placeID가 추가된 후 추후에 수정이 필요합니다.
             if self.isRevise {
-                let temp = self.scheduleState.currentSchedule
-                placeInteractor.appendPlaceList(place: Place(
-                    id: 0,
-                    x: temp.x,
-                    y: temp.y,
-                    name: temp.locationName,
-                    address: "임시용입니다",
-                    rodeAddress: "임시용입니다")
-                )
+                Task {
+                    let temp = self.scheduleState.currentSchedule
+                    let result = await placeInteractor.getPlaceList(query: temp.locationName)
+                    if let target = result?.first(where: { $0.x == temp.x && $0.y == temp.y }) {
+                        placeInteractor.appendPlaceList(place: target)
+                        placeInteractor.selectPlace(place: target)
+                    }
+                }
             }
             
             Task {

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoEditView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoEditView.swift
@@ -254,16 +254,17 @@ struct ToDoEditView: View {
                         }
                         .padding(.horizontal, 30)
                         
-                        // MARK: 카카오 맵 뷰
-                        KakaoMapView(draw: $draw, pinList: $appState.placeState.placeList, selectedPlace: $appState.placeState.selectedPlace)
-                            .onAppear(perform: {
-                                self.draw = true
-                            }).onDisappear(perform: {
-                                self.draw = false
-                            })
-                            .frame(width: 330, height:200)
-                            .border(Color.init(hex: 0xD9D9D9), width: 1)
-             
+                        if !((scheduleState.currentSchedule.x == 0.0 && scheduleState.currentSchedule.y == 0.0) || scheduleState.currentSchedule.locationName == "") {
+                            // MARK: 카카오 맵 뷰
+                            KakaoMapView(draw: $draw, pinList: $appState.placeState.placeList, selectedPlace: $appState.placeState.selectedPlace)
+                                .onAppear(perform: {
+                                    self.draw = true
+                                }).onDisappear(perform: {
+                                    self.draw = false
+                                })
+                                .frame(width: 330, height:200)
+                                .border(Color.init(hex: 0xD9D9D9), width: 1)
+                        }
                         Spacer()
                     }
                     .navigationTitle(self.isRevise ? "일정 편집" : "새 일정")

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoSelectPlaceView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoSelectPlaceView.swift
@@ -155,7 +155,7 @@ struct ToDoSelectPlaceView: View {
                         
                         Button(action: {
                             Task {
-                                await placeInteractor.getPlaceList(query:searchText)
+                                await placeInteractor.fetchPlaceList(query:searchText)
                             }
                         }) {
                             Text("검색")


### PR DESCRIPTION
## **Related Issue**
> 연관된 이슈번호를 작성해주세요 
Close #85 

## **Description**
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- ScheduleDTO 변경사항 적용
- 장소 미지정시 일정 편집화면에서 카카오 맵뷰 미표시
- 선택 장소 - 검색 장소 매칭 로직 추가
- 개인 / 모임 일정 날짜 선택 후 일정 추가시 해당 날짜 + 시간 적용 로직 추가
### **Screenshot (Optional)**

## **Requirements for Review**
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
기존 QA 사항 외 지도에서 발견된 특이사항도 수정했습니다.
+
Common : ScheduleDTO의 약간의 변동사항이 있습니다
HomeMain, GroupCalendar : 추가 버튼 탭시 Interactor 로직 추가되었습니다

