### PR TITLE
[FIX] 캘린더 position 계산을 매주 다시 계산하도록 변경

### DIFF
--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Moim/MoimInteractorImpl.swift
@@ -61,11 +61,18 @@ struct MoimInteractorImpl: MoimInteractor {
 			// 일정 지속기간 중 모든 day를 구함
 			let days = datesBetween(startDate: startDate, endDate: endDate)
 			
-			// 우선 시작날 캘린더에 표시될 postion을 구함(그 뒤 day들은 이 postion을 쭉 이어감)
-			let currentPosition = findPostion(schedulesDict[startYMD] ?? [])
+			// 우선 시작날 캘린더에 표시될 postion을 구함
+			// 그 뒤 day들은 이 postion을 쭉 이어감. 단 주가 바뀌고 해당 postion의 위쪽이 비어있다면 올라감
+			var currentPosition = findPostion(schedulesDict[startYMD] ?? [])
 			
 			// 일정 지속기간동안 매일
 			days.forEach { day in
+				// 만약 주가 바뀌면(일요일) position 다시 계산
+				if day.isSunday() {
+					currentPosition = findPostion(schedulesDict[day.toYMD()] ?? [])
+				}
+				
+				
 				let currentYMD = day.toYMD()
 				
 				// schedulesDict에 해당 날짜에 data가 nil이 아니라면 = 해당 날짜에 이미 스케쥴이 있다면

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractorImpl.swift
@@ -74,11 +74,17 @@ struct ScheduleInteractorImpl: ScheduleInteractor {
 			// 일정 지속기간 중 모든 day를 구함
 			let days = datesBetween(startDate: startDate, endDate: endDate)
 			
-			// 우선 시작날 캘린더에 표시될 postion을 구함(그 뒤 day들은 이 postion을 쭉 이어감)
-			let currentPosition = findPostion(schedulesDict[startYMD] ?? [])
+			// 우선 시작날 캘린더에 표시될 postion을 구함
+			// 그 뒤 day들은 이 postion을 쭉 이어감. 단 주가 바뀌고 해당 postion의 위쪽이 비어있다면 올라감
+			var currentPosition = findPostion(schedulesDict[startYMD] ?? [])
 			
 			// 일정 지속기간동안 매일
 			days.forEach { day in
+				// 만약 주가 바뀌면(일요일) position 다시 계산
+				if day.isSunday() {
+					currentPosition = findPostion(schedulesDict[day.toYMD()] ?? [])
+				}
+				
 				let currentYMD = day.toYMD()
 				
 				// schedulesDict에 해당 날짜에 data가 nil이 아니라면 = 해당 날짜에 이미 스케쥴이 있다면

--- a/Namo_SwiftUI/Namo_SwiftUI/Common/Extensions/Date+.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Common/Extensions/Date+.swift
@@ -92,4 +92,10 @@ extension Date {
 		return calendar.date(byAdding: .month, value: value, to: self)!
 		
 	}
+	
+	func isSunday() -> Bool {
+		let calendar = Calendar.current
+		let components = calendar.dateComponents([.weekday], from: self)
+		return components.weekday == 1 // 일요일
+	}
 }


### PR DESCRIPTION
## **Related Issue**
- #88 

## **Description**
기존 캘린더는 position을 구하면, 해당 position을 일정 끝까지 유지했습니다.
하지만 그러면 첫번째 사진 처럼 일정이 있는데도 하나도 안 보이는 이슈가 있습니다.

따라서 position을 계산을 주가 바뀔 때마다(일요일) 다시 계산해주는 걸로 수정했습니다.(두번째 사진)

### **Screenshot**
<img src="https://github.com/Namo-Mongmong/iOS_SwiftUI/assets/100191598/67d39aef-0d5d-47a5-bf9a-bd1a35ab373b" height="500"/>
<img src="https://github.com/Namo-Mongmong/iOS_SwiftUI/assets/100191598/a45ce33a-e013-4b58-9a9a-6259eeecfdfb" height="500"/>


