### PR TITLE
[Fix] 기록 관련 3차 QA

### DIFF
--- a/Namo_SwiftUI/Namo_SwiftUI/App/Namo_SwiftUIApp.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/App/Namo_SwiftUIApp.swift
@@ -35,6 +35,13 @@ struct Namo_SwiftUIApp: App {
         instance?.consumerKey = SecretConstants.naverLoginConsumerKey
         instance?.consumerSecret = SecretConstants.naverLoginClinetSecret
         instance?.appName = "나모"
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = UIColor.white
+        appearance.titleTextAttributes = [.foregroundColor: UIColor.black]
+        UINavigationBar.appearance().standardAppearance = appearance
+        UINavigationBar.appearance().compactAppearance = appearance
+        UINavigationBar.appearance().scrollEdgeAppearance = appearance
     }
     
     var body: some Scene {

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/DiaryInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/DiaryInteractor.swift
@@ -11,6 +11,7 @@ protocol DiaryInteractor {
     func createDiary(scheduleId: Int, content: String, images: [Data?]) async
     func getMonthDiary(request: GetDiaryRequestDTO) async
     func getOneDiary(scheduleId: Int) async
+    @discardableResult
     func changeDiary(scheduleId: Int, content: String, images: [Data?]) async -> Bool
     func deleteDiary(scheduleId: Int) async -> Bool
     func getMonthEngString(date: Date) -> String?

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/DiaryInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/DiaryInteractorImpl.swift
@@ -71,6 +71,7 @@ struct DiaryInteractorImpl: DiaryInteractor {
     }
     
     /// 기록 삭제
+    @discardableResult
     func deleteDiary(scheduleId: Int) async -> Bool {
         return await diaryRepository.deleteDiary(scheduleId: scheduleId)
     }

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractor.swift
@@ -16,4 +16,5 @@ protocol MoimDiaryInteractor {
     func deleteMoimDiary(moimMemoId: Int) async -> Bool
     func getMonthMoimDiary(req: GetMonthMoimDiaryReqDTO) async
     func getOneMoimDiary(moimScheduleId: Int ) async
+    func getOneMoimDiaryDetail(moimScheduleId: Int ) async
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractor.swift
@@ -12,6 +12,7 @@ protocol MoimDiaryInteractor {
     func createMoimDiaryPlace(moimScheduleId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
     func changeMoimDiaryPlace(moimLocationId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
     func deleteMoimDiaryPlace(moimLocationId: Int) async -> Bool
+    @discardableResult
     func editMoimDiary(scheduleId: Int, req: ChangeMoimDiaryRequestDTO) async -> Bool
     func deleteMoimDiary(moimMemoId: Int) async -> Bool
     func getMonthMoimDiary(req: GetMonthMoimDiaryReqDTO) async

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
@@ -61,4 +61,12 @@ struct MoimDiaryInteractorImpl: MoimDiaryInteractor {
             diaryState.currentMoimDiaryInfo = res
         }
     }
+    
+    /// 모임 메모 상세 조회
+    func getOneMoimDiaryDetail(moimScheduleId: Int) async {
+        guard let res = await moimDiaryRepository.getOneMoimDiaryDetail(moimScheduleId: moimScheduleId) else { return }
+        DispatchQueue.main.async {
+            diaryState.currentDiary = res
+        }
+    }
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
@@ -33,7 +33,6 @@ struct MoimDiaryInteractorImpl: MoimDiaryInteractor {
                     $0.moimActivityId != moimLocationId
                 }
             }
-            print("이거 제발 \(diaryState.currentMoimDiaryInfo.moimActivityDtos)")
             return true
         }
         return false

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
@@ -27,7 +27,16 @@ struct MoimDiaryInteractorImpl: MoimDiaryInteractor {
     
     /// 모임 메모 장소 삭제
     func deleteMoimDiaryPlace(moimLocationId: Int) async -> Bool {
-        return await moimDiaryRepository.deleteMoimDiaryPlace(moimLocationId: moimLocationId)
+        if await moimDiaryRepository.deleteMoimDiaryPlace(moimLocationId: moimLocationId) {
+            DispatchQueue.main.async {
+                diaryState.currentMoimDiaryInfo.moimActivityDtos = diaryState.currentMoimDiaryInfo.moimActivityDtos?.filter {
+                    $0.moimActivityId != moimLocationId
+                }
+            }
+            print("이거 제발 \(diaryState.currentMoimDiaryInfo.moimActivityDtos)")
+            return true
+        }
+        return false
     }
     
     /// 모임 기록에 대한 개인 메모 추가/수정

--- a/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Diary/MoimDiaryEndPoint.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Diary/MoimDiaryEndPoint.swift
@@ -16,6 +16,7 @@ enum MoimDiaryEndPoint {
     case deleteMoimDiary(moimMemoId: Int)
     case getMonthMoimDiary(request: GetMonthMoimDiaryReqDTO)
     case getOneMoimDiary(moimScheduleId: Int)
+    case getOneMoimDiaryDetail(moimScheduleId: Int)
 }
 
 extension MoimDiaryEndPoint: EndPoint {
@@ -38,12 +39,14 @@ extension MoimDiaryEndPoint: EndPoint {
             return "/text/\(scheduleId)"
         case .deleteMoimDiary(let moimMemoId):
             return "/all/\(moimMemoId)"
+        case .getOneMoimDiaryDetail(let moimScheduleId):
+            return "/detail/\(moimScheduleId)"
         }
     }
     
     var method: Alamofire.HTTPMethod {
         switch self {
-        case .getMonthMoimDiary, .getOneMoimDiary:
+        case .getMonthMoimDiary, .getOneMoimDiary, .getOneMoimDiaryDetail:
             return .get
         case .createMoimDiaryPlace:
             return .post
@@ -64,7 +67,7 @@ extension MoimDiaryEndPoint: EndPoint {
             return .uploadImagesWithBody(imageDatas: req.imgs, body: body)
         case .editMoimDiary(_, let req):
             return .requestJSONEncodable(parameters: req)
-        case .deleteMoimDiaryPlace, .deleteMoimDiary, .getOneMoimDiary:
+        case .deleteMoimDiaryPlace, .deleteMoimDiary, .getOneMoimDiary, .getOneMoimDiaryDetail:
             return .requestPlain
         case .getMonthMoimDiary(let req):
             let params = ["page": req.page, "size": req.size]

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
@@ -236,15 +236,13 @@ struct DiaryItemView: View {
     
     var body: some View {
         ZStack(alignment: .topLeading) {
-            Rectangle()
-                .fill(.textBackground)
-                .clipShape(RoundedCorners(radius: 10, corners: [.allCorners]))
-                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 0)
-            
-            Rectangle()
-                .fill(categoryInteractor.getColorWithPaletteId(id: 9))
-                .frame(width: 10)
-                .clipShape(RoundedCorners(radius: 10, corners: [.topLeft, .bottomLeft])) // 이거!!
+                Rectangle()
+                    .fill(.textBackground)
+                    .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 0)
+                
+                Rectangle()
+                    .fill(categoryInteractor.getColorWithPaletteId(id: diary.color))
+                    .frame(width: 10)
             
             HStack(alignment: .top, spacing: 25) {
                 // 제목과 수정 버튼
@@ -302,6 +300,7 @@ struct DiaryItemView: View {
             .padding(.trailing, 16)
             .padding(.bottom, 16)
         }
+        .clipShape(RoundedCorners(radius: 11, corners: [.allCorners]))
         .padding(.leading, 25)
         .padding(.trailing, 25)
     }

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
@@ -247,7 +247,6 @@ struct DiaryItemView: View {
                     Spacer()
                     
                     // 다이어리 수정 버튼
-                    // TODO: - categoryId 연결안됨
                     NavigationLink(destination: EditDiaryView(memo: diary.contents ?? "", urls: diary.urls ?? [], info: ScheduleInfo(scheduleId: diary.scheduleId, scheduleName: diary.name, date: Date(timeIntervalSince1970: Double(diary.startDate)), place: diary.placeName, categoryId: diary.categoryId))) {
                         HStack(alignment: .center, spacing: 3) {
                             Image(.icEditDiary)

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
@@ -267,9 +267,11 @@ struct DiaryItemView: View {
                 
                 // 내용과 사진
                 VStack(alignment: .leading, spacing: 12) {
-                    Text(diary.contents ?? "")
+                    Text(diary.contents?.replacingOccurrences(of: "\n", with: " ") ?? "")
                         .font(.pretendard(.light, size: 14))
                         .foregroundStyle(.mainText)
+                        .lineLimit(5)
+                        .truncationMode(.tail)
                     
                     // 사진 목록
                     // TODO: - 이미지 있는 기록이 잘 뜨는지 테스트 못 해봄

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
@@ -230,13 +230,14 @@ struct DiaryItemView: View {
             Rectangle()
                 .fill(.textBackground)
                 .clipShape(RoundedCorners(radius: 10, corners: [.allCorners]))
+                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 0)
             
             Rectangle()
-                .fill(categoryInteractor.getColorWithPaletteId(id: diary.color))
-                .clipShape(RoundedCorners(radius: 10, corners: [.topLeft, .bottomLeft]))
+                .fill(categoryInteractor.getColorWithPaletteId(id: 9))
                 .frame(width: 10)
+                .clipShape(RoundedCorners(radius: 10, corners: [.topLeft, .bottomLeft]))
             
-            HStack(alignment: .top, spacing: 15) {
+            HStack(alignment: .top, spacing: 25) {
                 // 제목과 수정 버튼
                 VStack(alignment: .leading, spacing: 0) {
                     Text(diary.name)
@@ -248,7 +249,7 @@ struct DiaryItemView: View {
                     
                     // 다이어리 수정 버튼
                     NavigationLink(destination: EditDiaryView(memo: diary.contents ?? "", urls: diary.urls ?? [], info: ScheduleInfo(scheduleId: diary.scheduleId, scheduleName: diary.name, date: Date(timeIntervalSince1970: Double(diary.startDate)), place: diary.placeName, categoryId: diary.categoryId))) {
-                        HStack(alignment: .center, spacing: 3) {
+                        HStack(alignment: .center, spacing: 5) {
                             Image(.icEditDiary)
                                 .resizable()
                                 .aspectRatio(contentMode: .fill)
@@ -265,7 +266,7 @@ struct DiaryItemView: View {
                 }
                 
                 // 내용과 사진
-                VStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 12) {
                     Text(diary.contents ?? "")
                         .font(.pretendard(.light, size: 14))
                         .foregroundStyle(.mainText)

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
@@ -244,7 +244,7 @@ struct DiaryItemView: View {
             Rectangle()
                 .fill(categoryInteractor.getColorWithPaletteId(id: 9))
                 .frame(width: 10)
-                .clipShape(RoundedCorners(radius: 10, corners: [.topLeft, .bottomLeft]))
+                .clipShape(RoundedCorners(radius: 10, corners: [.topLeft, .bottomLeft])) // 이거!!
             
             HStack(alignment: .top, spacing: 25) {
                 // 제목과 수정 버튼

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
@@ -236,13 +236,13 @@ struct DiaryItemView: View {
     
     var body: some View {
         ZStack(alignment: .topLeading) {
-                Rectangle()
-                    .fill(.textBackground)
-                    .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 0)
-                
-                Rectangle()
-                    .fill(categoryInteractor.getColorWithPaletteId(id: diary.color))
-                    .frame(width: 10)
+            Rectangle()
+                .fill(.textBackground)
+                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 0)
+            
+            Rectangle()
+                .fill(categoryInteractor.getColorWithPaletteId(id: diary.color))
+                .frame(width: 10)
             
             HStack(alignment: .top, spacing: 25) {
                 // 제목과 수정 버튼

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
@@ -164,7 +164,6 @@ struct DiaryMainView: View {
             }
         } // ZStack
         .task {
-			appState.isPersonalDiary = true
 			await loadDiaries()
         }
         .onChange(of: page) { _ in // 페이지 바뀔 때마다 호출되는 부분

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
@@ -196,6 +196,16 @@ struct ScheduleInfo: Hashable {
     let categoryId: Int?
 }
 
+extension ScheduleInfo {
+    func getSchedulePlace() -> String {
+        if place.isEmpty {
+            return "없음"
+        } else {
+            return place
+        }
+    }
+}
+
 // 다이어리 날짜 아이템
 struct DiaryDateItemView: View {
     let startDate: Int

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
@@ -38,7 +38,7 @@ struct EditDiaryView: View {
             VStack(alignment: .center) {
                 VStack(alignment: .leading) {
                     // 날짜와 장소 정보
-                    DatePlaceInfoView(date: info.date, place: info.place)
+                    DatePlaceInfoView(date: info.date, place: info.getSchedulePlace())
                     
                     // 메모 입력 부분
                     ZStack(alignment: .topLeading) {

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
@@ -259,20 +259,14 @@ struct EditDiaryView: View {
             .onAppear {
                 images.removeAll()
                 
-                Task {
-                    // 기록 개별 조회 API 호출
-                    await moimDiaryInteractor.getOneMoimDiaryDetail(moimScheduleId: info.scheduleId)
-                    // memo 값 연결
-                    memo = diaryState.currentDiary.contents ?? ""
-                    for url in diaryState.currentDiary.urls ?? [] {
-                        guard let url = URL(string: url) else { return }
-                        
-                        DispatchQueue.global().async {
-                            guard let data = try? Data(contentsOf: url) else { return }
-                            pickedImagesData.append(data)
-                            images.append(UIImage(data: data)!)
-                            print(images.description)
-                        }
+                for url in urls {
+                    guard let url = URL(string: url) else { return }
+                    
+                    DispatchQueue.global().async {
+                        guard let data = try? Data(contentsOf: url) else { return }
+                        pickedImagesData.append(data)
+                        images.append(UIImage(data: data)!)
+                        print(images.description)
                     }
                 }
             } // ScrollView

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
@@ -79,6 +79,7 @@ struct EditDiaryView: View {
                             }
                             .onChange(of: memo) { res in
                                 typedCharacters = memo.count
+                                memo = String(memo.prefix(characterLimit))
                                 diaryState.currentDiary.contents = String(memo.prefix(characterLimit))
                             }
                     } // ZStack

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
@@ -165,7 +165,7 @@ struct EditDiaryView: View {
             } else { // 모임 일정에 대한 개인 기록이면
                 Task {
                     // 기록 개별 조회 API 호출
-                    await diaryInteractor.getOneDiary(scheduleId: info.scheduleId)
+                    await moimDiaryInteractor.getOneMoimDiaryDetail(moimScheduleId: info.scheduleId)
                     // memo 값 연결
                     memo = diaryState.currentDiary.contents ?? ""
                     // TODO: - diaryState.currentDiary.urls 값이랑 이미지 연결

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
@@ -275,6 +275,7 @@ struct EditDiaryView: View {
                     
                     DispatchQueue.global().async {
                         guard let data = try? Data(contentsOf: url) else { return }
+                        pickedImagesData.append(data)
                         images.append(UIImage(data: data)!)
                         print(images.description)
                     }

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
@@ -266,6 +266,7 @@ struct EditMoimDiaryView: View {
                 self.activities = diaryState.currentMoimDiaryInfo.moimActivityDtos ?? []
             }
         }
+        .onAppear (perform : UIApplication.shared.hideKeyboard)
     }
     
     // 모임 기록 수정 완료 버튼 또는 기록 저장 버튼

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
@@ -280,6 +280,7 @@ struct EditMoimDiaryView: View {
                         if activities.indices.contains(i) {
                             let idList = diaryState.currentMoimDiaryInfo.getActivityIdList()
                             let req = EditMoimDiaryPlaceReqDTO(name: activities[i].name, money: String(activities[i].money), participants: moimUser.map { String($0.userId) }.joined(separator: ","), imgs: images)
+                            // TODO: - 이게 활동 변경인지 생성인지 구분해서 넣어줘야 됨 지금 이 if문으로는 구분이 안 되고 그래서 계속 에러남
                             if !idList.isEmpty {
                                 let res = await moimDiaryInteractor.changeMoimDiaryPlace(moimLocationId: idList[i], req: req)
                             } else {

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
@@ -279,11 +279,11 @@ struct EditMoimDiaryView: View {
                     for i in 0..<activities.count {
                         if activities.indices.contains(i) {
                             let idList = diaryState.currentMoimDiaryInfo.getActivityIdList()
-                            let req = EditMoimDiaryPlaceReqDTO(name: activities[i].name, money: String(activities[i].money), participants: activities[i].participants.map({String($0)}).joined(separator: ","), imgs: images)
+                            let req = EditMoimDiaryPlaceReqDTO(name: activities[i].name, money: String(activities[i].money), participants: moimUser.map { String($0.userId) }.joined(separator: ","), imgs: images)
                             if !idList.isEmpty {
-                                let _ = await moimDiaryInteractor.changeMoimDiaryPlace(moimLocationId: idList[i], req: req)
+                                let res = await moimDiaryInteractor.changeMoimDiaryPlace(moimLocationId: idList[i], req: req)
                             } else {
-                                let _ = await moimDiaryInteractor.createMoimDiaryPlace(moimScheduleId: info.scheduleId, req: req)
+                                let res = await moimDiaryInteractor.createMoimDiaryPlace(moimScheduleId: info.scheduleId, req: req)
                             }
                         }
                     }

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/MoimPlaceView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/MoimPlaceView.swift
@@ -33,9 +33,14 @@ struct MoimPlaceView: View {
             VStack(spacing: 0) {
                 // 장소 레이블
                 HStack(alignment: .top, spacing: 0) {
-                    TextField("\(activity.name)", text: $name)
-                        .font(.pretendard(.bold, size: 15))
-                        .foregroundStyle(.textPlaceholder)
+                    TextField(
+                        "\(activity.name)",
+                        text: $name,
+                        prompt: Text("활동 \(index+1)").foregroundColor(.textPlaceholder)
+                    )
+                    .font(.pretendard(.bold, size: 15))
+                    .foregroundStyle(.mainText)
+                    
                     Spacer()
                     HStack() {
                         Text("총 \(activity.money)원")
@@ -79,7 +84,7 @@ struct MoimPlaceView: View {
             ) // gesture
             .onAppear {
                 if activity.name.isEmpty {
-                    activity.name = "활동 \(index+1)"
+                    activity.name = ""
                 }
             }
             

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/CalendarScheduleDetailItem.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/CalendarScheduleDetailItem.swift
@@ -42,30 +42,18 @@ struct CalendarScheduleDetailItem: View {
 				
 				Spacer()
                 
-				if let hasDiary = schedule.hasDiary {
+                if let hasDiary = schedule.hasDiary {
                     NavigationLink(destination: EditDiaryView(memo: diaryState.currentDiary.contents ?? "", urls: [], info: ScheduleInfo(scheduleId: schedule.scheduleId, scheduleName: schedule.name, date: schedule.startDate, place: schedule.locationName, categoryId: schedule.categoryId))) {
-						Image(hasDiary ? .btnAddRecordOrange : .btnAddRecord)
-							.resizable()
-							.frame(width: 34, height: 34)
-							.padding(.trailing, 11)
-					}
-					.simultaneousGesture(TapGesture().onEnded {
-						scheduleInteractor.setScheduleToCurrentSchedule(schedule: schedule)
-						appState.isEditingDiary = false
-					})
-				}
-// 				Spacer(minLength: 0)
-				
-// 				Button(action: {
-//                     scheduleInteractor.setScheduleToCurrentSchedule(schedule: self.schedule)
-//                     self.isToDoSheetPresented = true
-//                 }, label: {
-// 					Image(schedule.hasDiary ? .btnAddRecordOrange : .btnAddRecord)
-// 						.resizable()
-// 						.frame(width: 34, height: 34)
-// 						.padding(.trailing, 11)
-// 				})
-				
+                        Image(hasDiary ? .btnAddRecordOrange : .btnAddRecord)
+                            .resizable()
+                            .frame(width: 34, height: 34)
+                            .padding(.trailing, 11)
+                    }
+                    .simultaneousGesture(TapGesture().onEnded {
+                        scheduleInteractor.setScheduleToCurrentSchedule(schedule: schedule)
+                        appState.isEditingDiary = false
+                    })
+                }
 			}
 			.frame(width: screenWidth-50, height: 55)
 			.background(

--- a/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepository.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepository.swift
@@ -16,4 +16,5 @@ protocol MoimDiaryRepository {
     func deleteMoimDiary(moimMemoId: Int) async -> Bool
     func getMonthMoimDiary(req: GetMonthMoimDiaryReqDTO) async -> GetMonthMoimDiaryResDTO?
     func getOneMoimDiary(moimScheduleId: Int) async -> GetOneMoimDiaryResDTO?
+    func getOneMoimDiaryDetail(moimScheduleId: Int) async -> Diary?
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepositoryImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepositoryImpl.swift
@@ -46,4 +46,10 @@ final class MoimDiaryRepositoryImpl: MoimDiaryRepository {
     func getOneMoimDiary(moimScheduleId: Int) async -> GetOneMoimDiaryResDTO? {
         return await APIManager.shared.performRequest(endPoint: MoimDiaryEndPoint.getOneMoimDiary(moimScheduleId: moimScheduleId))
     }
+    
+    func getOneMoimDiaryDetail(moimScheduleId: Int) async -> Diary? {
+        return await APIManager.shared.performRequest(
+            endPoint: MoimDiaryEndPoint.getOneMoimDiaryDetail(moimScheduleId: moimScheduleId)
+        )
+    }
 }


### PR DESCRIPTION
## **Related Issue**
- #95  

## **Description**
- 모임 기록 상세 조회 API 연동
- 텍스트만 편집했을 때 사진 없어지는 에러 해결
- 기록 아이템 레이아웃 및 스타일 수정
- 다이어리 메인에서는 기록 내용 줄바꿈 없애고 공백으로 처리
- TextEditor 200자 제한 적용
- 활동 placeholder 설정
- 장소 비었을 때 없음으로 설정
- 다른 화면 갔다가 와도 개인 / 모임 선택된 탭 유지
- 네비게이션 바 배경색 설정으로 뷰 겹치는 현상 해결
- 사진 중복 에러 해결
- 활동 편집 시 참가자 정보 전달 받도록 수정
- 기록 수정 화면 들어갈 때 이미지 연결 안 되는 에러 해결