### PR TITLE
[Fix] 기록 관련 3차 QA - 2

### DIFF
--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractor.swift
@@ -12,9 +12,8 @@ protocol MoimDiaryInteractor {
     func createMoimDiaryPlace(moimScheduleId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
     func changeMoimDiaryPlace(moimLocationId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
     func deleteMoimDiaryPlace(moimLocationId: Int) async -> Bool
-    @discardableResult
-    func editMoimDiary(scheduleId: Int, req: ChangeMoimDiaryRequestDTO) async -> Bool
-    func deleteMoimDiary(moimMemoId: Int) async -> Bool
+    @discardableResult func editMoimDiary(scheduleId: Int, req: ChangeMoimDiaryRequestDTO) async -> Bool
+    @discardableResult func deleteMoimDiary(moimScheduleId: Int) async -> Bool
     func getMonthMoimDiary(req: GetMonthMoimDiaryReqDTO) async
     func getOneMoimDiary(moimScheduleId: Int ) async
     func getOneMoimDiaryDetail(moimScheduleId: Int ) async

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractor.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractor.swift
@@ -10,8 +10,8 @@ import Foundation
 /// 모임 기록 API
 protocol MoimDiaryInteractor {
     func createMoimDiaryPlace(moimScheduleId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
-    func changeMoimDiaryPlace(moimLocationId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
-    func deleteMoimDiaryPlace(moimLocationId: Int) async -> Bool
+    func changeMoimDiaryPlace(activityId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
+    func deleteMoimDiaryPlace(activityId: Int) async -> Bool
     @discardableResult func editMoimDiary(scheduleId: Int, req: ChangeMoimDiaryRequestDTO) async -> Bool
     @discardableResult func deleteMoimDiary(moimScheduleId: Int) async -> Bool
     func getMonthMoimDiary(req: GetMonthMoimDiaryReqDTO) async

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
@@ -21,16 +21,16 @@ struct MoimDiaryInteractorImpl: MoimDiaryInteractor {
     }
     
     /// 모임 메모 장소 수정
-    func changeMoimDiaryPlace(moimLocationId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool {
-        return await moimDiaryRepository.changeMoimDiaryPlace(moimLocationId: moimLocationId, req: req)
+    func changeMoimDiaryPlace(activityId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool {
+        return await moimDiaryRepository.changeMoimDiaryPlace(activityId: activityId, req: req)
     }
     
     /// 모임 메모 장소 삭제
-    func deleteMoimDiaryPlace(moimLocationId: Int) async -> Bool {
-        if await moimDiaryRepository.deleteMoimDiaryPlace(moimLocationId: moimLocationId) {
+    func deleteMoimDiaryPlace(activityId: Int) async -> Bool {
+        if await moimDiaryRepository.deleteMoimDiaryPlace(activityId: activityId) {
             DispatchQueue.main.async {
                 diaryState.currentMoimDiaryInfo.moimActivityDtos = diaryState.currentMoimDiaryInfo.moimActivityDtos?.filter {
-                    $0.moimActivityId != moimLocationId
+                    $0.moimActivityId != activityId
                 }
             }
             return true

--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Diary/MoimDiaryInteractorImpl.swift
@@ -44,8 +44,8 @@ struct MoimDiaryInteractorImpl: MoimDiaryInteractor {
     }
     
     /// 모임 메모 삭제
-    func deleteMoimDiary(moimMemoId: Int) async -> Bool {
-        return await moimDiaryRepository.deleteMoimDiary(moimMemoId: moimMemoId)
+    func deleteMoimDiary(moimScheduleId: Int) async -> Bool {
+        return await moimDiaryRepository.deleteMoimDiary(moimScheduleId: moimScheduleId)
     }
     
     /// 월간 모임 메모 조회

--- a/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Diary/MoimDiaryEndPoint.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Diary/MoimDiaryEndPoint.swift
@@ -10,8 +10,8 @@ import Foundation
 
 enum MoimDiaryEndPoint {
     case createMoimDiaryPlace(moimScheduleId: Int, req: EditMoimDiaryPlaceReqDTO)
-    case changeMoimDiaryPlace(moimLocationId: Int, req: EditMoimDiaryPlaceReqDTO)
-    case deleteMoimDiaryPlace(moimLocationId: Int)
+    case changeMoimDiaryPlace(activityId: Int, req: EditMoimDiaryPlaceReqDTO)
+    case deleteMoimDiaryPlace(activityId: Int)
     case editMoimDiary(scheduleId: Int, req: ChangeMoimDiaryRequestDTO)
     case deleteMoimDiary(moimScheduleId: Int)
     case getMonthMoimDiary(request: GetMonthMoimDiaryReqDTO)
@@ -28,9 +28,9 @@ extension MoimDiaryEndPoint: EndPoint {
         switch self {
         case .createMoimDiaryPlace(let moimScheduleId, _):
             return "/\(moimScheduleId)"
-        case .changeMoimDiaryPlace(let moimLocationId, _),
-                .deleteMoimDiaryPlace(let moimLocationId):
-            return "/\(moimLocationId)"
+        case .changeMoimDiaryPlace(let activityId, _),
+                .deleteMoimDiaryPlace(let activityId):
+            return "/\(activityId)"
         case .getMonthMoimDiary(let req):
             return "/month/\(req.year),\(req.month)"
         case .getOneMoimDiary(let moimScheduleId):

--- a/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Diary/MoimDiaryEndPoint.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Diary/MoimDiaryEndPoint.swift
@@ -13,7 +13,7 @@ enum MoimDiaryEndPoint {
     case changeMoimDiaryPlace(moimLocationId: Int, req: EditMoimDiaryPlaceReqDTO)
     case deleteMoimDiaryPlace(moimLocationId: Int)
     case editMoimDiary(scheduleId: Int, req: ChangeMoimDiaryRequestDTO)
-    case deleteMoimDiary(moimMemoId: Int)
+    case deleteMoimDiary(moimScheduleId: Int)
     case getMonthMoimDiary(request: GetMonthMoimDiaryReqDTO)
     case getOneMoimDiary(moimScheduleId: Int)
     case getOneMoimDiaryDetail(moimScheduleId: Int)
@@ -37,8 +37,8 @@ extension MoimDiaryEndPoint: EndPoint {
             return "/\(moimScheduleId)"
         case .editMoimDiary(let scheduleId, _):
             return "/text/\(scheduleId)"
-        case .deleteMoimDiary(let moimMemoId):
-            return "/all/\(moimMemoId)"
+        case .deleteMoimDiary(let moimScheduleId):
+            return "/all/\(moimScheduleId)"
         case .getOneMoimDiaryDetail(let moimScheduleId):
             return "/detail/\(moimScheduleId)"
         }

--- a/Namo_SwiftUI/Namo_SwiftUI/Model/DTO/MoimDiaryDTO.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Model/DTO/MoimDiaryDTO.swift
@@ -91,27 +91,3 @@ extension GetOneMoimDiaryResDTO {
         } ?? []
     }
 }
-
-extension ActivityDTO {
-    func getDataList() -> [Data] {
-        var dataList: [Data] = []
-        for url in urls {
-            guard let url = URL(string: url) else { return [] }
-            
-            DispatchQueue.global().async {
-                guard let data = try? Data(contentsOf: url) else { return }
-                dataList.append(data)
-            }
-        }
-        return dataList
-    }
-    
-//    mutating func toUrlString(dataList: [Data?]) {
-//        for data in dataList {
-//            urls.append(String(decoding: data!, as: UTF8.self))
-//        }
-////        print("얜데")
-////        print(urls)
-//
-//    }
-}

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
@@ -111,11 +111,6 @@ struct EditDiaryView: View {
                         BlackBorderRoundedView(text: "모임 기록 보러가기", image: Image(.icDiary), width: 192, height: 40)
                     }
                     .padding(.bottom, 25)
-                    .simultaneousGesture(TapGesture().onEnded{
-                        Task {
-                            await moimDiaryInteractor.getOneMoimDiary(moimScheduleId: info.scheduleId)
-                        }
-                    })
                 }
                 
                 // 기록 저장 또는 기록 수정 버튼
@@ -153,24 +148,32 @@ struct EditDiaryView: View {
                     }
             }
         } // ZStack
-//        .onAppear {
-//            Task {
-//                // 기록 개별 조회 API 호출
-//                await moimDiaryInteractor.getOneMoimDiaryDetail(moimScheduleId: info.scheduleId)
-//                // memo 값 연결
-//                memo = diaryState.currentDiary.contents ?? ""
-//                for url in diaryState.currentDiary.urls ?? [] {
-//                    guard let url = URL(string: url) else { return }
-//                    
-//                    DispatchQueue.global().async {
-//                        guard let data = try? Data(contentsOf: url) else { return }
-//                        images.append(UIImage(data: data)!)
-//                        print(images.description)
-//                    }
-//                }
-////                    images = diaryState.currentDiary.urls
-//            }
-//        }
+        .onAppear {
+            images.removeAll()
+            Task {
+                if appState.isPersonalDiary {
+                    await diaryInteractor.getOneDiary(scheduleId: info.scheduleId)
+                } else {
+                    await moimDiaryInteractor.getOneMoimDiaryDetail(moimScheduleId: info.scheduleId)
+                }
+                // memo 값 연결
+                memo = diaryState.currentDiary.contents ?? ""
+                
+                print("@@@0528 editdiaryview \(diaryState.currentDiary)")
+                for url in diaryState.currentDiary.urls ?? [] {
+                    guard let url = URL(string: url) else { return }
+                    
+                    DispatchQueue.global().async {
+                        guard let data = try? Data(contentsOf: url) else { return }
+                        images.append(UIImage(data: data)!)
+                        print(images.description)
+                    }
+                }
+                print("@@@0528 개인, 캘린더에서 \(memo)")
+                print("@@@0528 memo \(memo)")
+                print("@@@0528 images \(images)")
+            }
+        }
         .onAppear (perform : UIApplication.shared.hideKeyboard)
     }
     
@@ -255,20 +258,20 @@ struct EditDiaryView: View {
                     }
                 }
             }
-            .onAppear {
-                images.removeAll()
-                
-                for url in urls {
-                    guard let url = URL(string: url) else { return }
-                    
-                    DispatchQueue.global().async {
-                        guard let data = try? Data(contentsOf: url) else { return }
-                        pickedImagesData.append(data)
-                        images.append(UIImage(data: data)!)
-                        print(images.description)
-                    }
-                }
-            } // ScrollView
+//            .onAppear {
+//                images.removeAll()
+//                
+//                for url in urls {
+//                    guard let url = URL(string: url) else { return }
+//                    
+//                    DispatchQueue.global().async {
+//                        guard let data = try? Data(contentsOf: url) else { return }
+//                        pickedImagesData.append(data)
+//                        images.append(UIImage(data: data)!)
+//                        print(images.description)
+//                    }
+//                }
+//            } // ScrollView
         }
     }
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
@@ -108,7 +108,7 @@ struct EditDiaryView: View {
                 // 모임 기록 보러가기 버튼
                 if !appState.isPersonalDiary {
                     // 활동 정보 연결되면 아래 코드로 테스트
-                    NavigationLink(destination: EditMoimDiaryView(activities: diaryState.currentMoimDiaryInfo.moimActivityDtos ?? [], images: pickedImagesData, info: info, moimUser: diaryState.currentMoimDiaryInfo.getMoimUsers())) {
+                    NavigationLink(destination: EditMoimDiaryView(activities: diaryState.currentMoimDiaryInfo.moimActivityDtos ?? [], info: info, moimUser: diaryState.currentMoimDiaryInfo.getMoimUsers())) {
                         BlackBorderRoundedView(text: "모임 기록 보러가기", image: Image(.icDiary), width: 192, height: 40)
                     }
                     .padding(.bottom, 25)

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
@@ -44,11 +44,9 @@ struct EditDiaryView: View {
                     ZStack(alignment: .topLeading) {
                         Rectangle()
                             .fill(.textBackground)
-                            .clipShape(RoundedCorners(radius: 10, corners: [.allCorners]))
                         
                         Rectangle()
                             .fill(categoryInteractor.getColorWithPaletteId(id: appState.categoryPalette[info.categoryId ?? 0] ?? 0))
-                            .clipShape(RoundedCorners(radius: 10, corners: [.topLeft, .bottomLeft]))
                             .frame(width: 10)
                         
                         // Place Holder
@@ -84,6 +82,7 @@ struct EditDiaryView: View {
                             }
                     } // ZStack
                     .frame(height: 150)
+                    .clipShape(RoundedCorners(radius: 11, corners: [.allCorners]))
                     
                     // 글자수 체크
                     HStack() {

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
@@ -45,7 +45,6 @@ struct EditMoimDiaryView: View {
             rightButtonAction: {
 				activities[currentCalculateIndex].money = Int(cost) ?? 0
 				activities[currentCalculateIndex].participants = selectedUser.map({$0.userId})
-				selectedUser.removeAll()
                 showCalculateAlert = false
                 return true
             },
@@ -111,13 +110,13 @@ struct EditMoimDiaryView: View {
                             HStack(spacing: 20) {
                                 Button(
                                     action: {
-                                        if selectedUser.contains(where: {$0 == user}) {
-                                            selectedUser.removeAll(where: {$0 == user})
+                                        if selectedUser.contains(where: {$0.userId == user.userId}) {
+                                            selectedUser.removeAll(where: {$0.userId == user.userId})
                                         } else {
                                             selectedUser.append(user)
                                         }
                                     }, label: {
-                                        Image(selectedUser.contains(where: {$0 == user}) ? .isSelectedTrue : .isSelectedFalse)
+                                        Image(selectedUser.contains(where: {$0.userId == user.userId}) ? .isSelectedTrue : .isSelectedFalse)
                                             .resizable()
                                             .frame(width: 20, height: 20)
                                     }
@@ -267,6 +266,22 @@ struct EditMoimDiaryView: View {
             }
         }
         .onAppear (perform : UIApplication.shared.hideKeyboard)
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("UpdateCalculateInfo"))) { noti in
+            if let userInfo = noti.userInfo, let currentCalculateIndex = userInfo["currentCalculateIndex"] as? Int {
+                Task {
+                    if currentCalculateIndex < activities.count {
+                        self.cost = String(activities[currentCalculateIndex].money)
+                        self.selectedUser.removeAll()
+                        for i in activities[currentCalculateIndex].participants {
+                            self.selectedUser.append(MoimUser(userId: i, userName: "", color: 0))
+                        }
+                    } else {
+                        self.cost = "0"
+                        self.selectedUser = []
+                    }
+                }
+            }
+        }
     }
     
     // 모임 기록 수정 완료 버튼 또는 기록 저장 버튼

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
@@ -261,6 +261,7 @@ struct EditMoimDiaryView: View {
         .ignoresSafeArea(edges: .bottom)
         .onAppear {
             Task {
+                self.activities.removeAll()
                 await moimDiaryInteractor.getOneMoimDiary(moimScheduleId: info.scheduleId)
                 self.activities = diaryState.currentMoimDiaryInfo.moimActivityDtos ?? []
             }

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditMoimDiaryView.swift
@@ -239,12 +239,12 @@ struct EditMoimDiaryView: View {
                     leftButtonTitle: "취소",
                     leftButtonAction: {},
                     rightButtonTitle: "삭제") {
-                        print("기록 삭제")
+                        print("모임 기록 삭제")
                         Task {
                             // 모임 기록 삭제
-                            await moimDiaryInteractor.deleteMoimDiary(moimMemoId: 1)
+                            await moimDiaryInteractor.deleteMoimDiary(moimScheduleId: info.scheduleId)
+                            self.presentationMode.wrappedValue.dismiss()
                         }
-                        self.presentationMode.wrappedValue.dismiss()
                     }
             }
             

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/MoimPlaceView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/MoimPlaceView.swift
@@ -53,6 +53,7 @@ struct MoimPlaceView: View {
                         withAnimation {
                             self.showCalculateAlert = true
                         }
+                        NotificationCenter.default.post(name: NSNotification.Name("UpdateCalculateInfo"), object: nil, userInfo: ["currentCalculateIndex":currentCalculateIndex])
                     }
                 }
                 .padding(.top, 20)

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/MoimPlaceView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/MoimPlaceView.swift
@@ -105,13 +105,11 @@ struct MoimPlaceView: View {
             }
         }
         .onAppear(perform: {
-            print("여기다~~")
-            print(activity)
             for url in activity.urls {
                 guard let url = URL(string: url) else { return }
-                
                 DispatchQueue.global().async {
                     guard let data = try? Data(contentsOf: url) else { return }
+                    pickedImagesData.append(data)
                     images.append(UIImage(data: data)!)
                     print(images.description)
                 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/CalendarScheduleDetailItem.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/CalendarScheduleDetailItem.swift
@@ -17,7 +17,6 @@ struct CalendarScheduleDetailItem: View {
 	
 	@Injected(\.scheduleInteractor) var scheduleInteractor
     @Injected(\.categoryInteractor) var categoryInteractor
-	@Injected(\.diaryInteractor) var diaryInteractor
 	
 	@Binding var isToDoSheetPresented: Bool
 	
@@ -43,7 +42,7 @@ struct CalendarScheduleDetailItem: View {
 				Spacer()
                 
                 if let hasDiary = schedule.hasDiary {
-                    NavigationLink(destination: EditDiaryView(memo: diaryState.currentDiary.contents ?? "", urls: [], info: ScheduleInfo(scheduleId: schedule.scheduleId, scheduleName: schedule.name, date: schedule.startDate, place: schedule.locationName, categoryId: schedule.categoryId))) {
+                    NavigationLink(destination: EditDiaryView(memo: diaryState.currentDiary.contents ?? "", urls: diaryState.currentDiary.urls ?? [], info: ScheduleInfo(scheduleId: schedule.scheduleId, scheduleName: schedule.name, date: schedule.startDate, place: schedule.locationName, categoryId: schedule.categoryId))) {
                         Image(hasDiary ? .btnAddRecordOrange : .btnAddRecord)
                             .resizable()
                             .frame(width: 34, height: 34)
@@ -51,7 +50,8 @@ struct CalendarScheduleDetailItem: View {
                     }
                     .simultaneousGesture(TapGesture().onEnded {
                         scheduleInteractor.setScheduleToCurrentSchedule(schedule: schedule)
-                        appState.isEditingDiary = false
+                        appState.isPersonalDiary = !schedule.moimSchedule
+                        appState.isEditingDiary = hasDiary
                     })
                 }
 			}
@@ -114,9 +114,6 @@ struct CalendarMoimScheduleDetailItem: View {
                 .simultaneousGesture(TapGesture().onEnded {
                     moimInteractor.setScheduleToCurrentMoimSchedule(schedule: self.schedule)
                     appState.isEditingDiary = schedule.hasDiaryPlace
-					Task {
-						await moimDiaryInteractor.getOneMoimDiary(moimScheduleId: schedule.moimScheduleId ?? 0)
-					}
                 })
 			} else {
 				Text(schedule.users.count == 1 ? schedule.users.first!.userName : "\(schedule.users.count)명")

--- a/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepository.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepository.swift
@@ -13,7 +13,7 @@ protocol MoimDiaryRepository {
     func changeMoimDiaryPlace(moimLocationId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
     func deleteMoimDiaryPlace(moimLocationId: Int) async -> Bool
     func editMoimDiary(scheduleId: Int, req: ChangeMoimDiaryRequestDTO) async -> Bool
-    func deleteMoimDiary(moimMemoId: Int) async -> Bool
+    func deleteMoimDiary(moimScheduleId: Int) async -> Bool
     func getMonthMoimDiary(req: GetMonthMoimDiaryReqDTO) async -> GetMonthMoimDiaryResDTO?
     func getOneMoimDiary(moimScheduleId: Int) async -> GetOneMoimDiaryResDTO?
     func getOneMoimDiaryDetail(moimScheduleId: Int) async -> Diary?

--- a/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepository.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepository.swift
@@ -10,8 +10,8 @@ import Foundation
 /// 모임 기록 API
 protocol MoimDiaryRepository {
     func createMoimDiaryPlace(moimScheduleId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
-    func changeMoimDiaryPlace(moimLocationId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
-    func deleteMoimDiaryPlace(moimLocationId: Int) async -> Bool
+    func changeMoimDiaryPlace(activityId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool
+    func deleteMoimDiaryPlace(activityId: Int) async -> Bool
     func editMoimDiary(scheduleId: Int, req: ChangeMoimDiaryRequestDTO) async -> Bool
     func deleteMoimDiary(moimScheduleId: Int) async -> Bool
     func getMonthMoimDiary(req: GetMonthMoimDiaryReqDTO) async -> GetMonthMoimDiaryResDTO?

--- a/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepositoryImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepositoryImpl.swift
@@ -15,14 +15,14 @@ final class MoimDiaryRepositoryImpl: MoimDiaryRepository {
         return response?.code == 200
     }
     
-    func changeMoimDiaryPlace(moimLocationId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool {
-        let response: BaseResponse<String>? = await APIManager.shared.performRequestBaseResponse(endPoint: MoimDiaryEndPoint.changeMoimDiaryPlace(moimLocationId: moimLocationId, req: req))
+    func changeMoimDiaryPlace(activityId: Int, req: EditMoimDiaryPlaceReqDTO) async -> Bool {
+        let response: BaseResponse<String>? = await APIManager.shared.performRequestBaseResponse(endPoint: MoimDiaryEndPoint.changeMoimDiaryPlace(activityId: activityId, req: req))
         print(response?.message)
         return response?.code == 200
     }
     
-    func deleteMoimDiaryPlace(moimLocationId: Int) async -> Bool {
-        let response: BaseResponse<String>? = await APIManager.shared.performRequestBaseResponse(endPoint: MoimDiaryEndPoint.deleteMoimDiaryPlace(moimLocationId: moimLocationId))
+    func deleteMoimDiaryPlace(activityId: Int) async -> Bool {
+        let response: BaseResponse<String>? = await APIManager.shared.performRequestBaseResponse(endPoint: MoimDiaryEndPoint.deleteMoimDiaryPlace(activityId: activityId))
         return response?.code == 200
     }
     

--- a/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepositoryImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Repository/Diary/MoimDiaryRepositoryImpl.swift
@@ -31,8 +31,8 @@ final class MoimDiaryRepositoryImpl: MoimDiaryRepository {
         return response?.code == 200
     }
     
-    func deleteMoimDiary(moimMemoId: Int) async -> Bool {
-        let response: BaseResponse<String>? = await APIManager.shared.performRequestBaseResponse(endPoint: MoimDiaryEndPoint.deleteMoimDiary(moimMemoId: moimMemoId))
+    func deleteMoimDiary(moimScheduleId: Int) async -> Bool {
+        let response: BaseResponse<String>? = await APIManager.shared.performRequestBaseResponse(endPoint: MoimDiaryEndPoint.deleteMoimDiary(moimScheduleId: moimScheduleId))
         print("모임 기록 삭제 완료")
         print(response)
         return response?.code == 200


### PR DESCRIPTION
## **Related Issue**
- #95 

## **Description**
- 활동 생성 시 임의의 activityId 0 값을 이용하여 활동 생성과 수정을 구분하여 API 요청 보낼 수 있게 수정
- 각 활동마다 images를 가지는 구조로 변경하여 복수개의 활동에 대한 사진 생성 및 수정이 가능하도록 함
- edit diary 화면 radius 값 수정
- 다이어리 탭에서만 잘 보이고 일정에서 기록으로 진입 시에는 이미지가 잘 연결 안 되는 에러가 있었으나 잘 보이도록 수정하였습니다. 기록 탭에서 수정한 게 일정에서 기록으로 진입 시에도 잘 보이고 그 반대도 가능해졌습니다.
- 모임 기록 삭제 API 필드값 수정 -> 모임 기록 삭제 가능해짐
- 활동별 정산 데이터 제대로 나오게 수정
- 정산 인원 체크 표시 유지 안 되는 에러 해결 + 활동 여러개일 때도 각자 다르게 설정할 수 있게 수정함
- 활동 이미지 이전에 조회한 활동 이미지로 나오는 에러 수정
- 장소 수정, 삭제 API 필드 이름 수정