### PR TITLE
[Fix] 기록 편집 시 이미지 삭제 + 중복 에러 통합 해결 완료

### DIFF
--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/DiaryMainView.swift
@@ -163,8 +163,10 @@ struct DiaryMainView: View {
                 )
             }
         } // ZStack
-        .task {
-			await loadDiaries()
+        .onAppear {
+            Task {
+                await loadDiaries()
+            }
         }
         .onChange(of: page) { _ in // 페이지 바뀔 때마다 호출되는 부분
             Task {
@@ -255,7 +257,7 @@ struct DiaryItemView: View {
                     Spacer()
                     
                     // 다이어리 수정 버튼
-                    NavigationLink(destination: EditDiaryView(memo: diary.contents ?? "", urls: diary.urls ?? [], info: ScheduleInfo(scheduleId: diary.scheduleId, scheduleName: diary.name, date: Date(timeIntervalSince1970: Double(diary.startDate)), place: diary.placeName, categoryId: diary.categoryId))) {
+                    NavigationLink(destination: EditDiaryView(isFromCalendar: false, memo: diary.contents ?? "", urls: diary.urls ?? [], info: ScheduleInfo(scheduleId: diary.scheduleId, scheduleName: diary.name, date: Date(timeIntervalSince1970: Double(diary.startDate)), place: diary.placeName, categoryId: diary.categoryId))) {
                         HStack(alignment: .center, spacing: 5) {
                             Image(.icEditDiary)
                                 .resizable()

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Diary/DiaryMain/EditDiaryView.swift
@@ -20,6 +20,7 @@ struct EditDiaryView: View {
     @Injected(\.diaryInteractor) var diaryInteractor
     @Injected(\.moimDiaryInteractor) var moimDiaryInteractor
     
+    @State var isFromCalendar: Bool
     @State var memo: String
     @State var placeholderText: String = "메모 입력"
     @State var typedCharacters = 0
@@ -149,29 +150,28 @@ struct EditDiaryView: View {
             }
         } // ZStack
         .onAppear {
-            images.removeAll()
-            Task {
-                if appState.isPersonalDiary {
-                    await diaryInteractor.getOneDiary(scheduleId: info.scheduleId)
-                } else {
-                    await moimDiaryInteractor.getOneMoimDiaryDetail(moimScheduleId: info.scheduleId)
-                }
-                // memo 값 연결
-                memo = diaryState.currentDiary.contents ?? ""
-                
-                print("@@@0528 editdiaryview \(diaryState.currentDiary)")
-                for url in diaryState.currentDiary.urls ?? [] {
-                    guard let url = URL(string: url) else { return }
+            if isFromCalendar {
+                // 아래의 작업은 캘린더에서 이 화면으로 넘어올 때만 필요해서 해당 불값을 추가함...
+                images.removeAll()
+                Task {
+                    if appState.isPersonalDiary {
+                        await diaryInteractor.getOneDiary(scheduleId: info.scheduleId)
+                    } else {
+                        await moimDiaryInteractor.getOneMoimDiaryDetail(moimScheduleId: info.scheduleId)
+                    }
+                    // memo 값 연결
+                    memo = diaryState.currentDiary.contents ?? ""
                     
-                    DispatchQueue.global().async {
-                        guard let data = try? Data(contentsOf: url) else { return }
-                        images.append(UIImage(data: data)!)
-                        print(images.description)
+                    for url in diaryState.currentDiary.urls ?? [] {
+                        guard let url = URL(string: url) else { return }
+                        
+                        DispatchQueue.global().async {
+                            guard let data = try? Data(contentsOf: url) else { return }
+                            images.append(UIImage(data: data)!)
+                            print(images.description)
+                        }
                     }
                 }
-                print("@@@0528 개인, 캘린더에서 \(memo)")
-                print("@@@0528 memo \(memo)")
-                print("@@@0528 images \(images)")
             }
         }
         .onAppear (perform : UIApplication.shared.hideKeyboard)
@@ -241,6 +241,20 @@ struct EditDiaryView: View {
                 }
             } // HStack
             .padding(.top, 18)
+            .onAppear {
+                pickedImagesData.removeAll()
+                images.removeAll()
+                
+                for url in urls {
+                    guard let url = URL(string: url) else { return }
+                    
+                    DispatchQueue.global().async {
+                        guard let data = try? Data(contentsOf: url) else { return }
+                        pickedImagesData.append(data)
+                        images.append(UIImage(data: data)!)
+                    }
+                }
+            }
             .onChange(of: pickedImageItems) { _ in
                 Task {
                     // 앞서 선택된 것들은 지우고
@@ -258,20 +272,6 @@ struct EditDiaryView: View {
                     }
                 }
             }
-//            .onAppear {
-//                images.removeAll()
-//                
-//                for url in urls {
-//                    guard let url = URL(string: url) else { return }
-//                    
-//                    DispatchQueue.global().async {
-//                        guard let data = try? Data(contentsOf: url) else { return }
-//                        pickedImagesData.append(data)
-//                        images.append(UIImage(data: data)!)
-//                        print(images.description)
-//                    }
-//                }
-//            } // ScrollView
         }
     }
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/CalendarScheduleDetailItem.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeMain/CalendarScheduleDetailItem.swift
@@ -42,7 +42,7 @@ struct CalendarScheduleDetailItem: View {
 				Spacer()
                 
                 if let hasDiary = schedule.hasDiary {
-                    NavigationLink(destination: EditDiaryView(memo: diaryState.currentDiary.contents ?? "", urls: diaryState.currentDiary.urls ?? [], info: ScheduleInfo(scheduleId: schedule.scheduleId, scheduleName: schedule.name, date: schedule.startDate, place: schedule.locationName, categoryId: schedule.categoryId))) {
+                    NavigationLink(destination: EditDiaryView(isFromCalendar: true, memo: diaryState.currentDiary.contents ?? "", urls: diaryState.currentDiary.urls ?? [], info: ScheduleInfo(scheduleId: schedule.scheduleId, scheduleName: schedule.name, date: schedule.startDate, place: schedule.locationName, categoryId: schedule.categoryId))) {
                         Image(hasDiary ? .btnAddRecordOrange : .btnAddRecord)
                             .resizable()
                             .frame(width: 34, height: 34)


### PR DESCRIPTION
## **Related Issue**
- #105 

## **Description**
1. 개인 기록 편집 시 이미지 수정 안 하고 바로 기록 수정 클릭하면 이미지가 삭제되는 버그가 존재했음
2. 주석 처리해뒀던 onAppear를 주석 해제하면 1의 버그는 해결되지만 기록 편집 화면에서 이미지가 2번씩 나오는 버그가 다시 생김
3. 결국 onAppear 2개가 다 필요한 건 맞는데 왜 이미지가 2번씩 나오는가... 생각해봄
4. 캘린더 -> 기록 편집 화면으로 전환했을 때를 위한 필요한 onAppear가 있음 (EditDiaryView 파일의 152번째 줄 onAppear)
5. 그러나 기록 메인 -> 기록 편집 화면으로 전환 시에는 그 onAppear가 필요없는데 그 이유는 기록 메인에서 해당 데이터를 전달받기 때문임
- 여기서 알 수 있는 이미지 중복됐던 이유) 이전 화면에서 받은 데이터 + 서버로부터 받은 데이터 append
6. 결론: `isFromCalendar` Bool 값을 추가하여 캘린더에서 진입했을 때만 4번 작업을 실행하도록 분기 처리하여 해결함