### PR TITLE
[PR#110] 일정 삭제 버그 및 일정 제목 공백 시 ToastMessage로 변경

### DIFF
--- a/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractorImpl.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Business/Interactor/Schedule/ScheduleInteractorImpl.swift
@@ -325,6 +325,9 @@ struct ScheduleInteractorImpl: ScheduleInteractor {
         }
         
         let result = await scheduleRepository.deleteSchedule(scheduleId: scheduleId, isMoim: false)
+		await MainActor.run {
+			NotificationCenter.default.post(name: .reloadCalendarViaNetwork, object: nil)
+		}
         print(String(describing: result))
     }
     

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupToDo/GroupToDoEditView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Group/GroupToDo/GroupToDoEditView.swift
@@ -37,6 +37,9 @@ struct GroupToDoEditView: View {
     /// 참석자 선택 창 Show State
     @State var showCheckParticipant: Bool = false
     @State var currPlace: Place?
+	
+	/// 일정 공백시  띄울 toast 변수
+	@State private var showToastTitleEmpty: Bool = false
 
     /// 날짜 포매터
     private let dateFormatter = DateFormatter()
@@ -184,8 +187,17 @@ struct GroupToDoEditView: View {
                                 Task {
                                     let name = scheduleState.currentMoimSchedule.name
                                     guard !name.isEmpty else {
-                                        print("@Log - \(scheduleState.currentMoimSchedule.name)")
-                                        ErrorHandler.shared.handle(type: .showAlert, error: .customError(title: "입력 오류", message: "일정 제목은 공백일 수 없습니다.", localizedDescription: nil))
+										await MainActor.run {
+											withAnimation {
+												self.showToastTitleEmpty = true
+											}
+										}
+										
+										DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+											withAnimation {
+												self.showToastTitleEmpty = false
+											}
+										}
                                         return
                                     }
                                     if self.isRevise {
@@ -258,6 +270,14 @@ struct GroupToDoEditView: View {
                     selectedUser: scheduleState.currentMoimSchedule.users
                 )
             }
+			
+			VStack {
+				Spacer()
+				
+				if showToastTitleEmpty {
+					ToastView(toastMessage: "일정 제목은 공백일 수 없습니다.", bottomPadding: 150)
+				}
+			}
             
         }
         .overlay(isShowSheet ? ToDoSelectPlaceView(isShowSheet: $isShowSheet, preMapDraw: $draw, isRevise: isRevise, tempPlace: currPlace, isGroup: true) : nil)

--- a/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoEditView.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Presentation/Home/HomeToDo/ToDoEditView.swift
@@ -52,6 +52,10 @@ struct ToDoEditView: View {
     
     /// NaivagionPath
     @State private var path = NavigationPath()
+	
+	/// 일정 공백시  띄울 toast 변수
+	@State private var showToastTitleEmpty: Bool = false
+	
     
     init() {
         // SwiftUI의 NavigationTitle는 Font가 적용되지 않습니다.
@@ -310,8 +314,17 @@ struct ToDoEditView: View {
                                 Task {
                                     let name = scheduleState.currentSchedule.name
                                     guard !name.isEmpty else {
-                                        print("@Log - \(scheduleState.currentSchedule.name)")
-                                        ErrorHandler.shared.handle(type: .showAlert, error: .customError(title: "입력 오류", message: "일정 제목은 공백일 수 없습니다.", localizedDescription: nil))
+										await MainActor.run {
+											withAnimation {
+												self.showToastTitleEmpty = true
+											}
+										}
+										
+										DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+											withAnimation {
+												self.showToastTitleEmpty = false
+											}
+										}
                                         return
                                     }
                                     
@@ -435,6 +448,14 @@ struct ToDoEditView: View {
                     }
                 )
             }
+			
+			VStack {
+				Spacer()
+				
+				if showToastTitleEmpty {
+					ToastView(toastMessage: "일정 제목은 공백일 수 없습니다.", bottomPadding: 150)
+				}
+			}
         }
         .overlay(isShowSheet ? ToDoSelectPlaceView(isShowSheet: $isShowSheet, preMapDraw: $draw, isRevise: isRevise, tempPlace: currPlace, isGroup: false) : nil)
         .ignoresSafeArea(.all, edges: .bottom)


### PR DESCRIPTION
## **Related Issue**
- #110

## **Description**
- 일정 삭제 후 캘린더 업데이트로 삭제 내용 적용
- 일정 제목 공백 시 alert 경고에서 toast띄우도록 변경

