### PR TITLE
[Feat] 토크 재발급 로직 추가 및 수정

### DIFF
--- a/Namo_SwiftUI/Namo_SwiftUI/Data/API/Auth/AuthManager.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Data/API/Auth/AuthManager.swift
@@ -61,76 +61,20 @@ class AuthManager: RequestInterceptor {
     ///     - completion: RetryResult를 처리하여 재시도 여부를 알려주는 비동기 클로저
     func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
         
-        // HTTP 응답 코드 확인, 재시도 여부 결정
-        guard let response = request.task?.response as? HTTPURLResponse,
-              response.statusCode == 401 || response.statusCode == 403 || response.statusCode == 404 else {
-            // 401 Unauthorized 또는 403 Forbidden 상태 코드가 아니라면, Error 메세지와 함께 재시도하지 않음
-            completion(.doNotRetryWithError(error))
-            return
+        print("=======retry 호출됨========")
+        
+        if request.retryCount < self.retryLimit {
+            
+            print("기존 요청 재시도")
+            
+            completion(.retry)
+        } else {
+            
+            // 네트워크 오류. 잠시 후 다시 시도해달라는 Alert 창을 띄움
+            ErrorHandler.shared.handleAPIError(.networkError)
+            
+            completion(.doNotRetry)
         }
         
-        // 해당 경로로 accessToken 재발급 요청
-        guard let url = URL(string: SecretConstants.baseURL+"/auths/reissuance") else { return }
-        
-        guard let accessToken = KeyChainManager.readItem(key: "accessToken"),
-              let refreshToken = KeyChainManager.readItem(key: "refreshToken")
-        else {
-            
-            // 토큰 없는 경우 에러 처리
-            
-            // 토큰이 없는 경우 isLogin = false -> 로그인 화면으로 이동
-            DispatchQueue.main.async {
-                UserDefaults.standard.set(false, forKey: "isLogin")
-                NaverThirdPartyLoginConnection.getSharedInstance().requestDeleteToken()
-            }
-            
-            // 이것처럼 처리도 가능
-            completion(.doNotRetryWithError(APIError.customError("[AuthManager] 키체인 토큰 조회 실패. 로그인이 필요합니다.(retry)")))
-            return
-        }
-        
-        // 여기는 대충 AF Req 생성 과정임
-        let parameters: Parameters = [
-            "accessToken": accessToken,
-            "refreshToken": refreshToken
-        ]
-        
-        AF.request(url,
-                   method: .post,
-                   parameters: parameters,
-                   encoding: JSONEncoding.default)
-        .validate()
-        .responseDecodable(of: SignInResponseDTO.self) { response in
-            switch response.result {
-            
-            // 재발급 성공
-            case .success(let result):
-                
-                // 재발급된 토큰을 키체인에 저장
-                KeyChainManager.addItem(key: "accessToken", value: result.accessToken)
-                KeyChainManager.addItem(key: "refreshToken", value: result.refreshToken)
-                
-                // 기존에 보내고자 했던 요청 재시도
-                // 재시도 횟수 내일 때만 재시도
-                request.retryCount < self.retryLimit ?
-                completion(.retry) : completion(.doNotRetry)
-//                completion(.retry) : completion(.doNotRetryWithError(APIError.customError("재시도 횟수 초과"))) //
-                
-            // 재발급 실패(refreshToken 만료)
-            case .failure(let error):
-                // 토큰 갱신 실패 시 에러 처리
-                print(error)
-                
-                // 로그인 화면으로 이동
-                DispatchQueue.main.async {
-                    UserDefaults.standard.set(false, forKey: "isLogin")
-                    NaverThirdPartyLoginConnection.getSharedInstance().requestDeleteToken()
-                }
-                
-                // 이것도 가능
-                completion(.doNotRetryWithError(error))
-                print("토큰 갱신 에러. 로그인 필요")
-            }
-        }
     }
 }

--- a/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Auth/AuthEndPoint.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Data/API/EndPoint/Auth/AuthEndPoint.swift
@@ -30,6 +30,10 @@ enum AuthEndPoint {
     
     // 로그아웃
     case logout(serverAccessToken: LogoutRequestDTO)
+    
+    // 토큰 재발급
+    case reissuanceToken(token: TokenReissuanceRequestDTO)
+    
 }
 
 extension AuthEndPoint: EndPoint {
@@ -62,12 +66,15 @@ extension AuthEndPoint: EndPoint {
             
         case .logout(serverAccessToken: _):
             return "/logout"
+            
+        case .reissuanceToken:
+            return "/reissuance"
         }
     }
     
     var method: Alamofire.HTTPMethod {
         switch self {
-        case .signInKakao, .signInNaver, .signInApple, .withdrawMemberKakao, .withdrawMemberNaver, .withdrawMemberApple, .logout:
+        case .signInKakao, .signInNaver, .signInApple, .withdrawMemberKakao, .withdrawMemberNaver, .withdrawMemberApple, .logout, .reissuanceToken:
             return .post
         }
     }
@@ -89,6 +96,8 @@ extension AuthEndPoint: EndPoint {
             return .requestPlain
         case .logout(serverAccessToken: let dto):
             return .authRequestJSONEncodable(parameters: dto)
+        case .reissuanceToken(token: let dto):
+            return .requestJSONEncodable(parameters: dto)
         }
     }
     

--- a/Namo_SwiftUI/Namo_SwiftUI/Model/DTO/AuthDTO.swift
+++ b/Namo_SwiftUI/Namo_SwiftUI/Model/DTO/AuthDTO.swift
@@ -51,3 +51,17 @@ struct TermRequest: Codable {
     let isCheckTermOfUse: Bool
     let isCheckPersonalInformationCollection: Bool
 }
+
+// 토큰 재발급 요청 DTO
+struct TokenReissuanceRequestDTO: Encodable {
+    
+    let accessToken: String
+    let refreshToken: String
+}
+
+// 토큰 재발급 응답 DTO
+struct TokenReissuanceResponseDTO: Decodable {
+    
+    let accessToken: String
+    let refreshToken: String
+}


### PR DESCRIPTION
## **Related Issue**
> 연관된 이슈번호를 작성해주세요 
> #119 

## **Description**
> 토큰 관련 DTO 추가 정의
> AuthEndPoint에 토큰 재발급 케이스 추가
> 기존 AuthManager에 있는 토큰 재발급 로직을 APIManager로 이동(AuthManager에서 작동하지 않던 문제 발견)

## **Requirements for Review**
> 기존 API 호출 사용법과 달라진 것은 없습니다. 그대로 사용하시면 됩니다.