### PR TITLE
[Refactor] 네이버 로그인 로직 리팩토링

### DIFF
--- a/Namo_SwiftUI/Projects/Core/Network/Sources/API/EndPoint/Auth/AuthEndPoint.swift
+++ b/Namo_SwiftUI/Projects/Core/Network/Sources/API/EndPoint/Auth/AuthEndPoint.swift
@@ -52,7 +52,7 @@ extension AuthEndPoint: EndPoint {
             return "/kakao/signup"
             
         case .signInNaver:
-            return "/naver/signup"
+            return "/signup/NAVER"
             
         case .signInApple:
             return "/signup/apple"

--- a/Namo_SwiftUI/Projects/Core/Network/Sources/API/EndPoint/Auth/AuthEndPoint.swift
+++ b/Namo_SwiftUI/Projects/Core/Network/Sources/API/EndPoint/Auth/AuthEndPoint.swift
@@ -49,7 +49,7 @@ extension AuthEndPoint: EndPoint {
         switch self {
             
         case .signInKakao:
-            return "/kakao/signup"
+            return "/signup/KAKAO"
             
         case .signInNaver:
             return "/signup/NAVER"

--- a/Namo_SwiftUI/Projects/Domain/Auth/DomainAuth.xcodeproj/project.pbxproj
+++ b/Namo_SwiftUI/Projects/Domain/Auth/DomainAuth.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		81AC377A2EEEFBBA72859FEF /* libSharedThirdPartyLib.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CA0ACAFB329012646CC4E670 /* libSharedThirdPartyLib.a */; };
 		83E51B4FC78E7699D92DDD6D /* Lottie_Lottie.bundle in Resources */ = {isa = PBXBuildFile; fileRef = DA4D5BE56DEC9F3EC70A209A /* Lottie_Lottie.bundle */; };
 		88323626F6B3CD01067FEC8E /* AuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50657C2ACD7A1548F44E7925 /* AuthClient.swift */; };
+		88B595FB2C9DB76A00DEB63F /* SNSLoginHelperInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88B595FA2C9DB76A00DEB63F /* SNSLoginHelperInterface.swift */; };
 		88C5770988A27E7C3AF86344 /* libDomainAuthInterface.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2D7803B06F4B9E27539E0548 /* libDomainAuthInterface.a */; };
 		8AC566B9E1BA2B2299DC3F34 /* GoogleAppMeasurementIdentitySupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80A6C5752503DB95468A2BEB /* GoogleAppMeasurementIdentitySupport.xcframework */; };
 		8C2BED9F82C2918133B53A6A /* SNSLoginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519B03D09547CE81C84653DD /* SNSLoginHelper.swift */; };
@@ -396,6 +397,7 @@
 		80A6C5752503DB95468A2BEB /* GoogleAppMeasurementIdentitySupport.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:EQHXZ8M8AV:Google LLC"; lastKnownFileType = wrapper.xcframework; path = GoogleAppMeasurementIdentitySupport.xcframework; sourceTree = "<group>"; };
 		80C4E6CED17919B89FB4DED5 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
 		84866AF0BE3EBF95134920F7 /* GoogleAppMeasurement.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:EQHXZ8M8AV:Google LLC"; lastKnownFileType = wrapper.xcframework; path = GoogleAppMeasurement.xcframework; sourceTree = "<group>"; };
+		88B595FA2C9DB76A00DEB63F /* SNSLoginHelperInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNSLoginHelperInterface.swift; sourceTree = "<group>"; };
 		89651178011A15E8364774F4 /* FirebaseAppCheckInterop.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FirebaseAppCheckInterop.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8C886F57CC04A917C174A0BF /* GoogleDataTransport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GoogleDataTransport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8DF84DF9B7212EBD3A4F1A94 /* FirebasePerformance.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FirebasePerformance.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -696,6 +698,7 @@
 		52FACDBB5CD203BE52C5B905 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				519B03D09547CE81C84653DD /* SNSLoginHelper.swift */,
 				50657C2ACD7A1548F44E7925 /* AuthClient.swift */,
 				91641F28076E5D0B97DCCE74 /* temp.swift */,
 			);
@@ -968,7 +971,7 @@
 			children = (
 				0823B29AE4C9A60E5F6E164B /* Models */,
 				FAB3F9E955B883598A12A8F4 /* AuthClientInterface.swift */,
-				519B03D09547CE81C84653DD /* SNSLoginHelper.swift */,
+				88B595FA2C9DB76A00DEB63F /* SNSLoginHelperInterface.swift */,
 				BF9487AA7FF0990CEBF89537 /* temp.swift */,
 			);
 			path = Sources;
@@ -1171,6 +1174,7 @@
 				B8390C25899FD1EF6ED4AA4A /* Token.swift in Sources */,
 				8C2BED9F82C2918133B53A6A /* SNSLoginHelper.swift in Sources */,
 				E56AC13906C3F706B6169B1C /* temp.swift in Sources */,
+				88B595FB2C9DB76A00DEB63F /* SNSLoginHelperInterface.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
@@ -26,6 +26,11 @@ public struct AuthClient {
         return await loginHelper.naverLogin()
     }
     
+    /// 카카오 로그인을 진행합니다. - Kakao 로그인 토큰 인증을 위한 정보를 받습니다.
+    public func kakaoLogin() async -> KakaoLoginInfo? {
+        return await loginHelper.kakaoLogin()
+    }
+    
     // MARK: API
     /// 나모 API : 애플 소셜 로그인을 통한 회원가입
     public var reqSignInWithApple: @Sendable (AppleSignInRequestDTO) async throws -> Tokens?

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
@@ -34,19 +34,22 @@ public struct AuthClient {
     // MARK: API
     /// 나모 API : 애플 소셜 로그인을 통한 회원가입
     public var reqSignInWithApple: @Sendable (AppleSignInRequestDTO) async throws -> Tokens?
-    // signInWithKakao
     /// 나모 API : 네이버 소셜 로그인을 통한 회원가입
     public var reqSignInWithNaver: @Sendable (SocialSignInRequestDTO) async throws -> Tokens?
+    /// 나모 API : 카카오 소셜 로그인을 통한 회원가입
+    public var reqSignInWithKakao: @Sendable (SocialSignInRequestDTO) async throws -> Tokens?
     // saveToken
     // loadToken
     public init(
         loginHelper: SNSLoginHelperProtocol,
         reqSignInWithApple: @Sendable @escaping (AppleSignInRequestDTO) async throws -> Tokens?,
-        reqSignInWithNaver: @Sendable @escaping (SocialSignInRequestDTO) async throws -> Tokens?
+        reqSignInWithNaver: @Sendable @escaping (SocialSignInRequestDTO) async throws -> Tokens?,
+        reqSignInWithKakao: @Sendable @escaping (SocialSignInRequestDTO) async throws -> Tokens?
     ) {
         self.loginHelper = loginHelper
         self.reqSignInWithApple = reqSignInWithApple
         self.reqSignInWithNaver = reqSignInWithNaver
+        self.reqSignInWithKakao = reqSignInWithKakao
     }
 }
 
@@ -54,12 +57,13 @@ extension AuthClient: TestDependencyKey {
     public static var previewValue = Self(
         loginHelper: unimplemented("\(Self.self).loginHelper"),
         reqSignInWithApple: unimplemented("\(Self.self).reqSignInWithApple"),
-        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver")
+        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver"), reqSignInWithKakao: unimplemented("\(Self.self).reqSignInWithKakao")
     )
     
     public static let testValue = Self(
         loginHelper: unimplemented("\(Self.self).loginHelper"),
         reqSignInWithApple: unimplemented("\(Self.self).reqSignInWithApple"),
-        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver")
+        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver"),
+        reqSignInWithKakao: unimplemented("\(Self.self).reqSignInWithKakao")
     )
 }

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
@@ -21,30 +21,40 @@ public struct AuthClient {
         return await loginHelper.appleLogin()
     }
     
+    /// 네이버 로그인을 진행합니다. - Naver 로그인 토큰 인증을 위한 정보를 받습니다.
+    public func naverLogin() async -> NaverLoginInfo? {
+        return await loginHelper.naverLogin()
+    }
+    
     // MARK: API
     /// 나모 API : 애플 소셜 로그인을 통한 회원가입
     public var reqSignInWithApple: @Sendable (AppleSignInRequestDTO) async throws -> Tokens?
     // signInWithKakao
-    // signInWithNaver
+    /// 나모 API : 네이버 소셜 로그인을 통한 회원가입
+    public var reqSignInWithNaver: @Sendable (SocialSignInRequestDTO) async throws -> Tokens?
     // saveToken
     // loadToken
     public init(
         loginHelper: SNSLoginHelperProtocol,
-        reqSignInWithApple: @Sendable @escaping (AppleSignInRequestDTO) async throws -> Tokens?
+        reqSignInWithApple: @Sendable @escaping (AppleSignInRequestDTO) async throws -> Tokens?,
+        reqSignInWithNaver: @Sendable @escaping (SocialSignInRequestDTO) async throws -> Tokens?
     ) {
         self.loginHelper = loginHelper
         self.reqSignInWithApple = reqSignInWithApple
+        self.reqSignInWithNaver = reqSignInWithNaver
     }
 }
 
 extension AuthClient: TestDependencyKey {
     public static var previewValue = Self(
         loginHelper: unimplemented("\(Self.self).loginHelper"),
-        reqSignInWithApple: unimplemented("\(Self.self).reqSignInWithApple")
+        reqSignInWithApple: unimplemented("\(Self.self).reqSignInWithApple"),
+        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver")
     )
     
     public static let testValue = Self(
         loginHelper: unimplemented("\(Self.self).loginHelper"),
-        reqSignInWithApple: unimplemented("\(Self.self).reqSignInWithApple")
+        reqSignInWithApple: unimplemented("\(Self.self).reqSignInWithApple"),
+        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver")
     )
 }

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/Models/Token.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/Models/Token.swift
@@ -13,5 +13,7 @@ public typealias AccessToken = String
 public typealias RefreshToken = String
 /// AccessToken, RefreshToken 튜플 명시를 위한 alias 입니다.
 public typealias Tokens = (accessToken: AccessToken, refreshToken: RefreshToken)
-/// AppleLoginInfo 튜플 명시를 위한 alias 입니다.
+/// AppleLoginInfo 구조체 명시를 위한 alias 입니다.
 public typealias AppleLoginInfo = AppleSignInRequestDTO
+/// NaverLoginInfo 구조체 명시를 위한 alias 입니다.
+public typealias NaverLoginInfo = SocialSignInRequestDTO

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/Models/Token.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/Models/Token.swift
@@ -17,3 +17,5 @@ public typealias Tokens = (accessToken: AccessToken, refreshToken: RefreshToken)
 public typealias AppleLoginInfo = AppleSignInRequestDTO
 /// NaverLoginInfo 구조체 명시를 위한 alias 입니다.
 public typealias NaverLoginInfo = SocialSignInRequestDTO
+/// KakaoLoginInfo 구조체 명시를 위한 alias 입니다.
+public typealias KakaoLoginInfo = SocialSignInRequestDTO

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/SNSLoginHelperInterface.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/SNSLoginHelperInterface.swift
@@ -9,4 +9,5 @@
 public protocol SNSLoginHelperProtocol {
     func appleLogin() async -> AppleLoginInfo?
     func naverLogin() async -> NaverLoginInfo?
+    func kakaoLogin() async -> KakaoLoginInfo?
 }

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/SNSLoginHelperInterface.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/SNSLoginHelperInterface.swift
@@ -1,0 +1,12 @@
+//
+//  SNSLoginHelperInterface.swift
+//  DomainAuthInterface
+//
+//  Created by 박민서 on 9/20/24.
+//
+
+/// SNSLoginHelper의 인터페이스 프로토콜입니다.
+public protocol SNSLoginHelperProtocol {
+    func appleLogin() async -> AppleLoginInfo?
+    func naverLogin() async -> NaverLoginInfo?
+}

--- a/Namo_SwiftUI/Projects/Domain/Auth/Sources/AuthClient.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Sources/AuthClient.swift
@@ -23,8 +23,11 @@ extension AuthClient: DependencyKey {
         },
         reqSignInWithNaver: { reqDTO in
             let res: BaseResponse<SignInResponseDTO>? = await APIManager.shared.performRequest(endPoint: AuthEndPoint.signInNaver(naverToken: reqDTO))
-            print("자 여기서 너가 어떻게 할지 보자고")
-            print(res)
+            guard let data = res?.result else { return nil }
+            return (data.accessToken, data.refreshToken)
+        },
+        reqSignInWithKakao: { reqDTO in
+            let res: BaseResponse<SignInResponseDTO>? = await APIManager.shared.performRequest(endPoint: AuthEndPoint.signInKakao(kakaoToken: reqDTO))
             guard let data = res?.result else { return nil }
             return (data.accessToken, data.refreshToken)
         }

--- a/Namo_SwiftUI/Projects/Domain/Auth/Sources/AuthClient.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Sources/AuthClient.swift
@@ -20,6 +20,13 @@ extension AuthClient: DependencyKey {
             let res: BaseResponse<SignInResponseDTO>? = await APIManager.shared.performRequest(endPoint: AuthEndPoint.signInApple(appleToken: reqDTO))
             guard let data = res?.result else { return nil }
             return (data.accessToken, data.refreshToken)
+        },
+        reqSignInWithNaver: { reqDTO in
+            let res: BaseResponse<SignInResponseDTO>? = await APIManager.shared.performRequest(endPoint: AuthEndPoint.signInNaver(naverToken: reqDTO))
+            print("자 여기서 너가 어떻게 할지 보자고")
+            print(res)
+            guard let data = res?.result else { return nil }
+            return (data.accessToken, data.refreshToken)
         }
     )
 }

--- a/Namo_SwiftUI/Projects/Domain/Auth/Sources/SNSLoginHelper.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Sources/SNSLoginHelper.swift
@@ -11,12 +11,6 @@ import NaverThirdPartyLogin
 import Core
 import SharedUtil
 
-/// SNSLoginHelper의 인터페이스 프로토콜입니다.
-public protocol SNSLoginHelperProtocol {
-    func appleLogin() async -> AppleLoginInfo?
-    func naverLogin() async -> NaverLoginInfo?
-}
-
 /// 소셜 로그인 진행을 위한 헬퍼 클래스입니다
 public final class SNSLoginHelper: NSObject, SNSLoginHelperProtocol {
     

--- a/Namo_SwiftUI/Projects/Domain/Auth/Sources/SNSLoginHelper.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Sources/SNSLoginHelper.swift
@@ -8,11 +8,18 @@
 import Foundation
 import AuthenticationServices
 import NaverThirdPartyLogin
+import KakaoSDKCommon
+import KakaoSDKAuth
+import KakaoSDKUser
 import Core
 import SharedUtil
 
 /// 소셜 로그인 진행을 위한 헬퍼 클래스입니다
 public final class SNSLoginHelper: NSObject, SNSLoginHelperProtocol {
+    
+    override public init() {
+        KakaoSDK.initSDK(appKey: SecretConstants.kakaoLoginAPIKey)
+    }
     
     // 클로저 저장을 위한 프로퍼티
     private var appleLoginCompletion: ((AppleLoginInfo?) -> Void)?
@@ -73,6 +80,16 @@ public final class SNSLoginHelper: NSObject, SNSLoginHelperProtocol {
             self.naverLoginCompletion = { loginInfo in
                 continuation.resume(returning: loginInfo)
             }
+        }
+    }
+    
+    // 카카오 로그인
+    public func kakaoLogin() async -> KakaoLoginInfo? {
+        return await loginWithKakao {
+            // 카카오 앱의 설치 유무에 따라 로그인 처리
+            return UserApi.isKakaoTalkLoginAvailable()
+            ? await self.loginWithKakaoTalk()
+            : await self.loginWithKakaoWeb()
         }
     }
 }
@@ -150,5 +167,56 @@ extension SNSLoginHelper: NaverThirdPartyLoginConnectionDelegate {
     public func oauth20Connection(_ oauthConnection: NaverThirdPartyLoginConnection!, didFailWithError error: (any Error)!) {
         print("Naver login failed: \(error.localizedDescription)")
         self.naverLoginCompletion?(nil)
+    }
+}
+
+// MARK: 카카오 로그인 Extension 구현
+extension SNSLoginHelper {
+    
+    /// 카카오톡(App) 로그인 처리를 async await로 래핑하는 함수입니다
+    @MainActor
+    private func loginWithKakaoTalk() async -> (OAuthToken?, Error?) {
+        return await withCheckedContinuation { continuation in
+            UserApi.shared.loginWithKakaoTalk { (oauthToken, error) in
+                continuation.resume(returning: (oauthToken, error))
+            }
+        }
+    }
+    
+    /// 카카오톡(Web) 로그인 처리를 async await로 래핑하는 함수입니다
+    @MainActor
+    private func loginWithKakaoWeb() async -> (OAuthToken?, Error?) {
+        return await withCheckedContinuation { continuation in
+            UserApi.shared.loginWithKakaoAccount { (oauthToken, error) in
+                continuation.resume(returning: (oauthToken, error))
+            }
+        }
+    }
+    
+    /// 공통된 카카오 로그인 로직을 async/await 방식으로 처리
+    /// - Parameters:
+    ///   - loginMethod: 로그인 방식 (카카오톡 또는 웹 로그인을 선택적으로 처리)
+    /// - Returns: 성공 시 `KakaoLoginInfo`를 반환하고, 실패(에러, 토큰x) 시 nil을 반환합니다.
+    private func loginWithKakao(
+        loginMethod: @escaping () async -> (OAuthToken?, Error?)
+    ) async -> KakaoLoginInfo? {
+        let (oauthToken, error) = await loginMethod()
+        
+        if let error = error {
+            print("kakao login failed: \(error.localizedDescription)")
+            return nil // 에러 발생 시 nil 반환
+        }
+        
+        guard
+            let kakaoAccessToken = oauthToken?.accessToken,
+            let kakaoRefreshToken = oauthToken?.refreshToken
+        else {
+            return nil // 토큰이 없을 시 nil 반환
+        }
+        
+        return KakaoLoginInfo(
+            accessToken: kakaoAccessToken,
+            socialRefreshToken: kakaoRefreshToken
+        )
     }
 }

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
@@ -26,6 +26,7 @@ public struct OnboardingLoginStore {
         case kakaoLoginButtonTapped
         case naverLoginButtonTapped
         case appleLoginButtonTapped
+        case namoNaverLoginResponse(SocialSignInRequestDTO)
         case namoAppleLoginResponse(AppleSignInRequestDTO)
     }
     
@@ -40,15 +41,31 @@ public struct OnboardingLoginStore {
             case .kakaoLoginButtonTapped:
                 print("kakao")
                 return .none
+                
             case .naverLoginButtonTapped:
                 print("naver")
-                return .none
+                return .run { send in
+                    guard let data = await authClient.naverLogin() else { return }
+                    let reqData = data as SocialSignInRequestDTO
+                    await send(.namoNaverLoginResponse(reqData))
+                }
+                
             case .appleLoginButtonTapped:
                 print("apple")
                 return .run { send in
                     guard let data = await authClient.appleLogin() else { return }
                     let reqData = data as AppleSignInRequestDTO
                     await send(.namoAppleLoginResponse(reqData))
+                }
+                
+            case .namoNaverLoginResponse(let reqData):
+                print("namo naver")
+                return .run { send in
+                    if let result = try await authClient.reqSignInWithNaver(reqData) {
+                        print("result as Token type is \(result)")
+                    } else {
+                        print("인생은 니뜻대로 되지않는단다")
+                    }
                 }
                 
             case .namoAppleLoginResponse(let reqData):

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
@@ -40,7 +40,11 @@ public struct OnboardingLoginStore {
                 
             case .kakaoLoginButtonTapped:
                 print("kakao")
-                return .none
+                return .run { send in
+                    guard let data = await authClient.kakaoLogin() else { return }
+                    let reqData = data as SocialSignInRequestDTO
+                    print(reqData)
+                }
                 
             case .naverLoginButtonTapped:
                 print("naver")

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
@@ -26,6 +26,7 @@ public struct OnboardingLoginStore {
         case kakaoLoginButtonTapped
         case naverLoginButtonTapped
         case appleLoginButtonTapped
+        case namoKakaoLoginResponse(SocialSignInRequestDTO)
         case namoNaverLoginResponse(SocialSignInRequestDTO)
         case namoAppleLoginResponse(AppleSignInRequestDTO)
     }
@@ -43,7 +44,7 @@ public struct OnboardingLoginStore {
                 return .run { send in
                     guard let data = await authClient.kakaoLogin() else { return }
                     let reqData = data as SocialSignInRequestDTO
-                    print(reqData)
+                    await send(.namoKakaoLoginResponse(reqData))
                 }
                 
             case .naverLoginButtonTapped:
@@ -60,6 +61,16 @@ public struct OnboardingLoginStore {
                     guard let data = await authClient.appleLogin() else { return }
                     let reqData = data as AppleSignInRequestDTO
                     await send(.namoAppleLoginResponse(reqData))
+                }
+                
+            case .namoKakaoLoginResponse(let reqData):
+                print("namo kakao")
+                return .run { send in
+                    if let result = try await authClient.reqSignInWithKakao(reqData) {
+                        print("result as Token type is \(result)")
+                    } else {
+                        print("인생은 니뜻대로 되지않는단다")
+                    }
                 }
                 
             case .namoNaverLoginResponse(let reqData):


### PR DESCRIPTION
## **Related Issue**
> 연관된 이슈번호를 작성해주세요 
#167

## **Description**
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


애플 로그인 리팩토링에 이어 네이버 로그인을 리팩토링 했습니다.
v2에서 수정된 사항을 반영하고, 현재 구조에 맞춰 리팩토링을 진행했습니다.
추가로, SNSLoginHelper의 Interface와 구현체를 별도로 분리하여 Inteface 모듈과 본 모듈에 각각 재위치시켰습니다.

## **Requirements for Review**
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
**!! 해당 PR은 Approve만 해주시고, 머지는 제가 진행하겠습니다! !!**
