### PR TITLE
[Refactor] 카카오 로그인 로직 리팩토링

### DIFF
--- a/Namo_SwiftUI/Projects/Core/Network/Sources/API/EndPoint/Auth/AuthEndPoint.swift
+++ b/Namo_SwiftUI/Projects/Core/Network/Sources/API/EndPoint/Auth/AuthEndPoint.swift
@@ -49,7 +49,7 @@ extension AuthEndPoint: EndPoint {
         switch self {
             
         case .signInKakao:
-            return "/kakao/signup"
+            return "/signup/KAKAO"
             
         case .signInNaver:
             return "/signup/NAVER"

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
@@ -26,6 +26,11 @@ public struct AuthClient {
         return await loginHelper.naverLogin()
     }
     
+    /// 카카오 로그인을 진행합니다. - Kakao 로그인 토큰 인증을 위한 정보를 받습니다.
+    public func kakaoLogin() async -> KakaoLoginInfo? {
+        return await loginHelper.kakaoLogin()
+    }
+    
     // MARK: API
     /// 나모 API : 애플 소셜 로그인을 통한 회원가입
     public var reqSignInWithApple: @Sendable (AppleSignInRequestDTO) async throws -> Tokens?

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/AuthClientInterface.swift
@@ -34,19 +34,22 @@ public struct AuthClient {
     // MARK: API
     /// 나모 API : 애플 소셜 로그인을 통한 회원가입
     public var reqSignInWithApple: @Sendable (AppleSignInRequestDTO) async throws -> Tokens?
-    // signInWithKakao
     /// 나모 API : 네이버 소셜 로그인을 통한 회원가입
     public var reqSignInWithNaver: @Sendable (SocialSignInRequestDTO) async throws -> Tokens?
+    /// 나모 API : 카카오 소셜 로그인을 통한 회원가입
+    public var reqSignInWithKakao: @Sendable (SocialSignInRequestDTO) async throws -> Tokens?
     // saveToken
     // loadToken
     public init(
         loginHelper: SNSLoginHelperProtocol,
         reqSignInWithApple: @Sendable @escaping (AppleSignInRequestDTO) async throws -> Tokens?,
-        reqSignInWithNaver: @Sendable @escaping (SocialSignInRequestDTO) async throws -> Tokens?
+        reqSignInWithNaver: @Sendable @escaping (SocialSignInRequestDTO) async throws -> Tokens?,
+        reqSignInWithKakao: @Sendable @escaping (SocialSignInRequestDTO) async throws -> Tokens?
     ) {
         self.loginHelper = loginHelper
         self.reqSignInWithApple = reqSignInWithApple
         self.reqSignInWithNaver = reqSignInWithNaver
+        self.reqSignInWithKakao = reqSignInWithKakao
     }
 }
 
@@ -54,12 +57,13 @@ extension AuthClient: TestDependencyKey {
     public static var previewValue = Self(
         loginHelper: unimplemented("\(Self.self).loginHelper"),
         reqSignInWithApple: unimplemented("\(Self.self).reqSignInWithApple"),
-        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver")
+        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver"), reqSignInWithKakao: unimplemented("\(Self.self).reqSignInWithKakao")
     )
     
     public static let testValue = Self(
         loginHelper: unimplemented("\(Self.self).loginHelper"),
         reqSignInWithApple: unimplemented("\(Self.self).reqSignInWithApple"),
-        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver")
+        reqSignInWithNaver: unimplemented("\(Self.self).reqSignInWithNaver"),
+        reqSignInWithKakao: unimplemented("\(Self.self).reqSignInWithKakao")
     )
 }

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/Models/Token.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/Models/Token.swift
@@ -17,3 +17,5 @@ public typealias Tokens = (accessToken: AccessToken, refreshToken: RefreshToken)
 public typealias AppleLoginInfo = AppleSignInRequestDTO
 /// NaverLoginInfo 구조체 명시를 위한 alias 입니다.
 public typealias NaverLoginInfo = SocialSignInRequestDTO
+/// KakaoLoginInfo 구조체 명시를 위한 alias 입니다.
+public typealias KakaoLoginInfo = SocialSignInRequestDTO

--- a/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/SNSLoginHelperInterface.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Interface/Sources/SNSLoginHelperInterface.swift
@@ -9,4 +9,5 @@
 public protocol SNSLoginHelperProtocol {
     func appleLogin() async -> AppleLoginInfo?
     func naverLogin() async -> NaverLoginInfo?
+    func kakaoLogin() async -> KakaoLoginInfo?
 }

--- a/Namo_SwiftUI/Projects/Domain/Auth/Sources/AuthClient.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Sources/AuthClient.swift
@@ -23,8 +23,11 @@ extension AuthClient: DependencyKey {
         },
         reqSignInWithNaver: { reqDTO in
             let res: BaseResponse<SignInResponseDTO>? = await APIManager.shared.performRequest(endPoint: AuthEndPoint.signInNaver(naverToken: reqDTO))
-            print("자 여기서 너가 어떻게 할지 보자고")
-            print(res)
+            guard let data = res?.result else { return nil }
+            return (data.accessToken, data.refreshToken)
+        },
+        reqSignInWithKakao: { reqDTO in
+            let res: BaseResponse<SignInResponseDTO>? = await APIManager.shared.performRequest(endPoint: AuthEndPoint.signInKakao(kakaoToken: reqDTO))
             guard let data = res?.result else { return nil }
             return (data.accessToken, data.refreshToken)
         }

--- a/Namo_SwiftUI/Projects/Domain/Auth/Sources/SNSLoginHelper.swift
+++ b/Namo_SwiftUI/Projects/Domain/Auth/Sources/SNSLoginHelper.swift
@@ -8,11 +8,18 @@
 import Foundation
 import AuthenticationServices
 import NaverThirdPartyLogin
+import KakaoSDKCommon
+import KakaoSDKAuth
+import KakaoSDKUser
 import Core
 import SharedUtil
 
 /// 소셜 로그인 진행을 위한 헬퍼 클래스입니다
 public final class SNSLoginHelper: NSObject, SNSLoginHelperProtocol {
+    
+    override public init() {
+        KakaoSDK.initSDK(appKey: SecretConstants.kakaoLoginAPIKey)
+    }
     
     // 클로저 저장을 위한 프로퍼티
     private var appleLoginCompletion: ((AppleLoginInfo?) -> Void)?
@@ -73,6 +80,16 @@ public final class SNSLoginHelper: NSObject, SNSLoginHelperProtocol {
             self.naverLoginCompletion = { loginInfo in
                 continuation.resume(returning: loginInfo)
             }
+        }
+    }
+    
+    // 카카오 로그인
+    public func kakaoLogin() async -> KakaoLoginInfo? {
+        return await loginWithKakao {
+            // 카카오 앱의 설치 유무에 따라 로그인 처리
+            return UserApi.isKakaoTalkLoginAvailable()
+            ? await self.loginWithKakaoTalk()
+            : await self.loginWithKakaoWeb()
         }
     }
 }
@@ -150,5 +167,56 @@ extension SNSLoginHelper: NaverThirdPartyLoginConnectionDelegate {
     public func oauth20Connection(_ oauthConnection: NaverThirdPartyLoginConnection!, didFailWithError error: (any Error)!) {
         print("Naver login failed: \(error.localizedDescription)")
         self.naverLoginCompletion?(nil)
+    }
+}
+
+// MARK: 카카오 로그인 Extension 구현
+extension SNSLoginHelper {
+    
+    /// 카카오톡(App) 로그인 처리를 async await로 래핑하는 함수입니다
+    @MainActor
+    private func loginWithKakaoTalk() async -> (OAuthToken?, Error?) {
+        return await withCheckedContinuation { continuation in
+            UserApi.shared.loginWithKakaoTalk { (oauthToken, error) in
+                continuation.resume(returning: (oauthToken, error))
+            }
+        }
+    }
+    
+    /// 카카오톡(Web) 로그인 처리를 async await로 래핑하는 함수입니다
+    @MainActor
+    private func loginWithKakaoWeb() async -> (OAuthToken?, Error?) {
+        return await withCheckedContinuation { continuation in
+            UserApi.shared.loginWithKakaoAccount { (oauthToken, error) in
+                continuation.resume(returning: (oauthToken, error))
+            }
+        }
+    }
+    
+    /// 공통된 카카오 로그인 로직을 async/await 방식으로 처리
+    /// - Parameters:
+    ///   - loginMethod: 로그인 방식 (카카오톡 또는 웹 로그인을 선택적으로 처리)
+    /// - Returns: 성공 시 `KakaoLoginInfo`를 반환하고, 실패(에러, 토큰x) 시 nil을 반환합니다.
+    private func loginWithKakao(
+        loginMethod: @escaping () async -> (OAuthToken?, Error?)
+    ) async -> KakaoLoginInfo? {
+        let (oauthToken, error) = await loginMethod()
+        
+        if let error = error {
+            print("kakao login failed: \(error.localizedDescription)")
+            return nil // 에러 발생 시 nil 반환
+        }
+        
+        guard
+            let kakaoAccessToken = oauthToken?.accessToken,
+            let kakaoRefreshToken = oauthToken?.refreshToken
+        else {
+            return nil // 토큰이 없을 시 nil 반환
+        }
+        
+        return KakaoLoginInfo(
+            accessToken: kakaoAccessToken,
+            socialRefreshToken: kakaoRefreshToken
+        )
     }
 }

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
@@ -40,7 +40,11 @@ public struct OnboardingLoginStore {
                 
             case .kakaoLoginButtonTapped:
                 print("kakao")
-                return .none
+                return .run { send in
+                    guard let data = await authClient.kakaoLogin() else { return }
+                    let reqData = data as SocialSignInRequestDTO
+                    print(reqData)
+                }
                 
             case .naverLoginButtonTapped:
                 print("naver")

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingLogin/OnboardingLoginStore.swift
@@ -26,6 +26,7 @@ public struct OnboardingLoginStore {
         case kakaoLoginButtonTapped
         case naverLoginButtonTapped
         case appleLoginButtonTapped
+        case namoKakaoLoginResponse(SocialSignInRequestDTO)
         case namoNaverLoginResponse(SocialSignInRequestDTO)
         case namoAppleLoginResponse(AppleSignInRequestDTO)
     }
@@ -43,7 +44,7 @@ public struct OnboardingLoginStore {
                 return .run { send in
                     guard let data = await authClient.kakaoLogin() else { return }
                     let reqData = data as SocialSignInRequestDTO
-                    print(reqData)
+                    await send(.namoKakaoLoginResponse(reqData))
                 }
                 
             case .naverLoginButtonTapped:
@@ -60,6 +61,16 @@ public struct OnboardingLoginStore {
                     guard let data = await authClient.appleLogin() else { return }
                     let reqData = data as AppleSignInRequestDTO
                     await send(.namoAppleLoginResponse(reqData))
+                }
+                
+            case .namoKakaoLoginResponse(let reqData):
+                print("namo kakao")
+                return .run { send in
+                    if let result = try await authClient.reqSignInWithKakao(reqData) {
+                        print("result as Token type is \(result)")
+                    } else {
+                        print("인생은 니뜻대로 되지않는단다")
+                    }
                 }
                 
             case .namoNaverLoginResponse(let reqData):


### PR DESCRIPTION
## **Related Issue**
> 연관된 이슈번호를 작성해주세요 
#167

## **Description**
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

네이버 로그인 리팩토링에 이어 카카오 로그인을 리팩토링 했습니다.
v2에서 수정된 사항을 반영하고, 현재 구조에 맞춰 리팩토링을 진행했습니다.
추가로, async/await로 카카오 로그인 로직을 랩핑하는 과정에서 기존 공식문서와 조금 달라보일 수 있습니다..!
SNSLoginHelper의 Extension으로 작성한 것은 별도의 프로토콜 없이 작성한 것이라 주석을 조금 상세히 달아놓았습니다.

## **Requirements for Review**
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
**!! 해당 PR은 Approve만 해주시고, 머지는 제가 진행하겠습니다! !!**
