### PR TITLE
[Feat] 로그인 Flow를 추가합니다(임시)

### DIFF
--- a/Namo_SwiftUI/Projects/App/Sources/MainTab/MainTabCoordinator.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/MainTab/MainTabCoordinator.swift
@@ -42,7 +42,6 @@ struct MainTabCoordinator {
             default:
                 return .none
             }            
-        }
-        
+        }        
     }
 }

--- a/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnBoardingCoordinator.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnBoardingCoordinator.swift
@@ -8,10 +8,29 @@
 import Foundation
 import ComposableArchitecture
 import TCACoordinators
+import FeatureOnboarding
+import SharedUtil
 
 @Reducer
 struct OnBoardingCoordinator {
-    struct State: Equatable {}
+    struct State: Equatable {
+        var onBoarding: OnboardingLoginStore.State
+    }
     
-    enum Action {}
+    enum Action {
+        case onboarding(OnboardingLoginStore.Action)
+    }
+    
+    var body: some ReducerOf<Self> {
+        Scope(state: \.onBoarding, action: \.onboarding) {
+            OnboardingLoginStore()
+        }
+        
+        Reduce<State, Action> { state, action in
+            switch action {       
+            default:
+                return .none
+            }
+        }
+    }
 }

--- a/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnBoardingCoordinatorView.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnBoardingCoordinatorView.swift
@@ -8,11 +8,12 @@
 import SwiftUI
 import ComposableArchitecture
 import TCACoordinators
+import FeatureOnboarding
 
 struct OnBoardingCoordinatorView: View {
     let store: StoreOf<OnBoardingCoordinator>
     
     var body: some View {
-        Text("Onboarding")
+        OnboardingLoginView(store: store.scope(state: \.onBoarding, action: \.onboarding))
     }
 }

--- a/Namo_SwiftUI/Projects/App/Sources/Root/AppCoordinator.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Root/AppCoordinator.swift
@@ -50,7 +50,7 @@ struct AppCoordinator {
         
         Reduce<State, Action> { state, action in
 
-            switch action {
+            switch action {            
             case .router(.routeAction(_, action: .onBoarding(.onboarding(.namoAppleLoginResponse(_))))):
                 state.routes = [.root(.mainTab(.init(home: .initialState, moim: .initialState)), embedInNavigationView: true)]
             case .router(.routeAction(_, action: .splash(.goToOnboardingScreen))):

--- a/Namo_SwiftUI/Projects/App/Sources/Root/AppCoordinator.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Root/AppCoordinator.swift
@@ -27,7 +27,7 @@ struct AppCoordinator {
         static let initialState = State(routes: [.root(.splash(.init()), embedInNavigationView: true)],
                                         mainTab: .intialState,
                                         splash: .init(),
-                                        onBoarding: .init())
+                                        onBoarding: .init(onBoarding: .init()))
         var routes: [Route<AppScreen.State>]
         var mainTab: MainTabCoordinator.State
         var splash: SplashCoordinator.State
@@ -49,14 +49,14 @@ struct AppCoordinator {
         }
         
         Reduce<State, Action> { state, action in
-            switch action {                                  
-            case .router(.routeAction(_, action: .splash(.loginCheck(let isSuccess)))):
-                if isSuccess {
-					state.routes = [.root(.mainTab(.init(home: .initialState, moim: .initialState)), embedInNavigationView: true)]
-                } else {
-                    state.routes = [.root(.onBoarding(.init()), embedInNavigationView: true)]
-                }
-                return .none
+
+            switch action {
+            case .router(.routeAction(_, action: .onBoarding(.onboarding(.namoAppleLoginResponse(_))))):
+                state.routes = [.root(.mainTab(.init(home: .initialState, moim: .initialState)), embedInNavigationView: true)]
+            case .router(.routeAction(_, action: .splash(.goToOnboardingScreen))):
+                state.routes = [.root(.onBoarding(.init(onBoarding: .init())), embedInNavigationView: true)]
+            case .router(.routeAction(_, action: .splash(.goToMainScreen))):
+                state.routes = [.root(.mainTab(.init(home: .initialState, moim: .initialState)), embedInNavigationView: true)]
             default:
                 break
             }

--- a/Namo_SwiftUI/Projects/App/Sources/Root/RootApp.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Root/RootApp.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import TCACoordinators
 import ComposableArchitecture
+import FeatureOnboarding
+import SharedUtil
 
 @main
 struct RootApp: App {
@@ -17,6 +19,6 @@ struct RootApp: App {
             AppCoordinatorView(store: Store(initialState: .initialState, reducer: {
                 AppCoordinator()
             }))
-        }
+        }        
     }
 }

--- a/Namo_SwiftUI/Projects/App/Sources/Splash/SplashCoordinator.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Splash/SplashCoordinator.swift
@@ -29,12 +29,18 @@ struct SplashCoordinator {
         
         Reduce<State, Action> { state, action in
             switch action {
-            case .loginCheck:                
+            case .loginCheck:
                 if authClient.getLoginState() != nil {
                     return .send(.goToMainScreen)
                 } else {
                     return .send(.goToOnboardingScreen)
                 }
+                
+//                로그아웃은 임시로 해당 주석을 풀어서 사용해주세요
+//                return .run { send in
+//                    await authClient.setLogoutState(with: .apple)
+//                    await send(.goToOnboardingScreen)
+//                }
             default:
                 return .none
             }

--- a/Namo_SwiftUI/Projects/App/Sources/Splash/SplashCoordinator.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Splash/SplashCoordinator.swift
@@ -8,12 +8,36 @@
 import Foundation
 import ComposableArchitecture
 import TCACoordinators
+import SharedUtil
 
 @Reducer
 struct SplashCoordinator {
-    struct State: Equatable {}
+    @Dependency(\.authClient) var authClient
+    
+    struct State: Equatable {
+        var isLogin: Bool = false        
+    }
     
     enum Action {
-        case loginCheck(isSuccess: Bool)
+        case loginCheck
+        case goToOnboardingScreen
+        case goToMainScreen
+    }
+    
+    var body: some ReducerOf<Self> {
+        
+        
+        Reduce<State, Action> { state, action in
+            switch action {
+            case .loginCheck:                
+                if authClient.getLoginState() != nil {
+                    return .send(.goToMainScreen)
+                } else {
+                    return .send(.goToOnboardingScreen)
+                }
+            default:
+                return .none
+            }
+        }
     }
 }

--- a/Namo_SwiftUI/Projects/App/Sources/Splash/SplashCoordinatorView.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Splash/SplashCoordinatorView.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 import ComposableArchitecture
 import TCACoordinators
+import SharedUtil
 
 struct SplashCoordinatorView: View {
     let store: StoreOf<SplashCoordinator>
     
     var body: some View {
-        Text("Splash")
+        Text("Splash 임시")
             .onAppear {
-                store.send(.loginCheck(isSuccess: true))
+                store.send(.loginCheck)
             }
     }
 }

--- a/Namo_SwiftUI/Projects/Core/Network/Sources/API/Base/APIManager.swift
+++ b/Namo_SwiftUI/Projects/Core/Network/Sources/API/Base/APIManager.swift
@@ -47,7 +47,7 @@ public final class APIManager {
             result = try request.result.get()
         } catch {
             print("네트워크 에러" + (String(data: result, encoding: .utf8) ?? ""))
-            throw APIError.networkError(error.errorDescription)
+            throw APIError.networkError(error.localizedDescription)
         }
         
         do {

--- a/Namo_SwiftUI/Projects/Domain/Schedule/Sources/UseCase/ScheduleUseCase.swift
+++ b/Namo_SwiftUI/Projects/Domain/Schedule/Sources/UseCase/ScheduleUseCase.swift
@@ -21,7 +21,7 @@ public struct ScheduleUseCase {
 		let startDateString = String(format: "%04d-%02d-%02d", startDate.year, startDate.month, startDate.day)
 		let endDateString = String(format: "%04d-%02d-%02d", endDate.year, endDate.month, endDate.day)
 		
-		let response: BaseResponse<GetMonthlyScheduleResponseDTO>? = await APIManager.shared.performRequest(
+		let response: BaseResponse<GetMonthlyScheduleResponseDTO>? = try? await APIManager.shared.performRequest(
 			endPoint: ScheduleEndPoint.getSchedule(
 				startDate: startDateString, endDate: endDateString
 			)

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingInfoInput/OnboardingInfoInputStore.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingInfoInput/OnboardingInfoInputStore.swift
@@ -6,7 +6,7 @@
 //
 
 import ComposableArchitecture
-import SwiftUICore
+import SwiftUI
 
 /// InfoInput 작성 시 내용 구분용으로 사용하는 enum입니다
 public enum InfoFormState: Equatable {

--- a/Namo_SwiftUI/Projects/Feature/Sources/FeatureExport.swift
+++ b/Namo_SwiftUI/Projects/Feature/Sources/FeatureExport.swift
@@ -10,3 +10,5 @@
 @_exported import FeatureHome
 @_exported import FeatureMoim
 @_exported import FeatureCalendar
+@_exported import FeatureOnboarding
+


### PR DESCRIPTION
## **Related Issue**
x

## **Description**
토큰여부를 검사하고 화면을 이동하는 코디네이터를 로직을 추가했습니다.

**+ 추가설명**
로그아웃 관련한 UI가 아직 없기떄문에 귀찮더라도 해당 주석을 풀어서 빌드해주는 방식으로 진행합니다.
해당 파일은 앱모듈 SplashCoordinator에 있습니다.
```swift
    var body: some ReducerOf<Self> {
        
        Reduce<State, Action> { state, action in
            switch action {
            case .loginCheck:
                if authClient.getLoginState() != nil {
                    return .send(.goToMainScreen)
                } else {
                    return .send(.goToOnboardingScreen)
                }
                
//                로그아웃은 임시로 해당 주석을 풀어서 사용해주세요
//                return .run { send in
//                    await authClient.setLogoutState(with: .apple)
//                    await send(.goToOnboardingScreen)
//                }
            default:
                return .none
            }
        }
    }
```
### **Screenshot (Optional)**

## **Requirements for Review**
api 작업을 하는데 불편함이 예상되어 cherry-pick으로 임시로 작업한 커밋을 적용했습니다. 어디까지나 임시이기 떄문에 추후에 수정이 필요할 것 같습니다.
