### PR TITLE
[Feat] 앱 첫 진입 시 수행 로직 추가 작성

### DIFF
--- a/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnBoardingCoordinatorView.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnBoardingCoordinatorView.swift
@@ -30,7 +30,7 @@ struct OnboardingCoordinatorView: View {
             }
         }
         .onAppear {
-            store.send(.loginCheck)
+            store.send(.initialCheck)
         }
     }
 }

--- a/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnBoardingCoordinatorView.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnBoardingCoordinatorView.swift
@@ -17,6 +17,8 @@ struct OnboardingCoordinatorView: View {
         TCARouter(store.scope(state: \.routes, action: \.router)) { screen in
             switch screen.case {
                 
+            case let .splash(store):
+                OnboardingSplashView(store: store)
             case let .login(store):
                 OnboardingLoginView(store: store)
             case let .agreement(store):

--- a/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnboardingCoordinator.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnboardingCoordinator.swift
@@ -33,7 +33,7 @@ struct OnboardingCoordinator {
         // 버전 체크 여부 플래그
         var hasPerformedVersionCheck: Bool = false
         // 버전 업데이트 필요 표시 플래그
-        var showUpdateRequired: Bool = false
+        @Shared(.inMemory(SharedKeys.showUpdateRequired.rawValue)) var showUpdateRequired: Bool = false
         // 로그인 체크 여부 플래그
         var hasPerformedLoginCheck: Bool = false
         

--- a/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnboardingCoordinator.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnboardingCoordinator.swift
@@ -24,11 +24,16 @@ enum OnboardingScreen {
 struct OnboardingCoordinator {
     
     @Dependency(\.authClient) var authClient
+    private let remoteConfig = RemoteConfigManager()
     
     @ObservableState
     struct State: Equatable {
         
         var routes: [Route<OnboardingScreen.State>]
+        // 버전 체크 여부 플래그
+        var hasPerformedVersionCheck: Bool = false
+        // 버전 업데이트 필요 표시 플래그
+        var showUpdateRequired: Bool = false
         // 로그인 체크 여부 플래그
         var hasPerformedLoginCheck: Bool = false
         
@@ -46,6 +51,12 @@ struct OnboardingCoordinator {
     enum Action {
         case router(IndexedRouterActionOf<OnboardingScreen>)
         
+        // 초기 체크
+        case initialCheck
+        // 버전 체크
+        case versionCheck
+        // 버전 체크 결과
+        case versionCheckResponse(Result<Bool, Error>)
         // 로그인 체크
         case loginCheck
         // 로그인 화면
@@ -88,6 +99,39 @@ struct OnboardingCoordinator {
                 default:
                     return .none
                 }
+            
+                // 초기 체크 -> 버전 체크로 시작
+            case .initialCheck:
+                return .send(.versionCheck)
+                
+                // 버전 체크
+            case .versionCheck:
+                guard !state.hasPerformedVersionCheck else { return .none }
+                state.hasPerformedVersionCheck = true
+
+                return .run { send in
+                    do {
+                        let updateRequired = try await remoteConfig.checkUpdateRequired()
+//                        if let baseUrl = try await remoteConfig.getBaseUrl() {
+//                            // TODO: BaseURL의 용도 체크 필요
+//                        } else {
+//                            throw NSError(domain: "API 테스트 실패", code: 1001)
+//                        }
+                        await send(.versionCheckResponse(.success(updateRequired)))
+                    } catch {
+                        await send(.versionCheckResponse(.failure(error)))
+                    }
+                }
+                
+            case .versionCheckResponse(.success(let updateRequired)):
+                state.showUpdateRequired = updateRequired
+                // 로그인 체크로 라우팅
+                return .send(.loginCheck)
+                
+            case .versionCheckResponse(.failure(let error)):
+                print("최소 버전 가져오기 실패: \(error.localizedDescription)")
+                // TODO: 앱 끌건지 체크 필요
+                return .none           
                 
                 // 로그인 체크 결과 라우팅
             case .loginCheck:

--- a/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnboardingCoordinator.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Onboarding/OnboardingCoordinator.swift
@@ -13,6 +13,7 @@ import SharedUtil
 
 @Reducer(state: .equatable)
 enum OnboardingScreen {
+    case splash(OnboardingSplashStore)
     case login(OnboardingLoginStore)
     case agreement(OnboardingTOSStore)
     case userInfo(OnboardingInfoInputStore)
@@ -32,7 +33,7 @@ struct OnboardingCoordinator {
         var hasPerformedLoginCheck: Bool = false
         
         static let initialState: State = .init(
-            routes: [.root(.login(.init()))] // 첫 화면은 로그인
+            routes: [.root(.splash(.init()))]
         )
         
         static func routedState(_ routes: [Route<OnboardingScreen.State>]) -> State {
@@ -112,16 +113,22 @@ struct OnboardingCoordinator {
                 }
                 
             case .goToLoginScreen:
-                state.routes.push(.login(.init()))
+                state.routes = [.root(.login(.init()), embedInNavigationView: true)]
                 return .none
                 
             case .goToAgreementScreen:
-                state.routes.push(.agreement(.init()))
+                state.routes = [
+                    .root(.login(.init())),
+                    .push(.agreement(.init()))
+                ]
                 return .none
                 
             case .goToUserInfoScreen:
                 // TODO: 추후 기획 확정 시 수정
-                state.routes.push(.userInfo(.init(name: nil)))
+                state.routes = [
+                    .root(.login(.init())),
+                    .push(.userInfo(.init(name: nil)))
+                ]
                 return .none
                 
             case .goToSignUpCompletion:

--- a/Namo_SwiftUI/Projects/App/Sources/Root/RootApp.swift
+++ b/Namo_SwiftUI/Projects/App/Sources/Root/RootApp.swift
@@ -10,15 +10,20 @@ import TCACoordinators
 import ComposableArchitecture
 import FeatureOnboarding
 import SharedUtil
+import Firebase
 
 @main
 struct RootApp: App {
+    
+    init() {
+        FirebaseApp.configure()
+    }
     
     var body: some Scene {
         WindowGroup {
             AppCoordinatorView(store: Store(initialState: .initialState, reducer: {
                 AppCoordinator()
             }))
-        }        
+        }
     }
 }

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingSplash/OnboardingSplashStore.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingSplash/OnboardingSplashStore.swift
@@ -30,10 +30,6 @@ public struct OnboardingSplashStore {
         case goUpdateButtonTapped
         /// 앱 업데이트 취소 버튼 탭
         case cancelUpdateButtonTapped
-        /// 앱 스타팅 체크 로직 종료
-        case appCheckDone
-        /// 다음 화면 이동
-        case moveNextScreen
     }
     
     /// 타이머
@@ -58,17 +54,6 @@ public struct OnboardingSplashStore {
             case .cancelUpdateButtonTapped:
                 print("exit this app")
                 return .none
-                
-            case .moveNextScreen:
-                print("move to next page")
-                return .none
-                
-            case .appCheckDone:
-                return .run { send in
-                    // 타이머 1초 기다린 후 send
-                    try await self.clock.sleep(for: .seconds(1))
-                    await send(.moveNextScreen)
-                }
             }
         }
     }

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingSplash/OnboardingSplashStore.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingSplash/OnboardingSplashStore.swift
@@ -6,7 +6,8 @@
 //
 
 import ComposableArchitecture
-import Shared
+import SharedUtil
+import UIKit
 
 @Reducer
 public struct OnboardingSplashStore {
@@ -48,6 +49,10 @@ public struct OnboardingSplashStore {
                 
             case .goUpdateButtonTapped:
                 print("go to app store")
+                if let url = URL(string: SecretConstants.namoAppStoreURL),
+                   UIApplication.shared.canOpenURL(url) {
+                    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                }
                 return .none
                 
             case .cancelUpdateButtonTapped:

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingSplash/OnboardingSplashStore.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingSplash/OnboardingSplashStore.swift
@@ -6,6 +6,7 @@
 //
 
 import ComposableArchitecture
+import Shared
 
 @Reducer
 public struct OnboardingSplashStore {
@@ -17,11 +18,9 @@ public struct OnboardingSplashStore {
         /// 앱 스타팅 체크 로직  플래그
         var isChecking: Bool = false
         /// 업데이트 필요 표시 플래그
-        var showUpdateRequired: Bool = false
+        @Shared(.inMemory(SharedKeys.showUpdateRequired.rawValue)) var showUpdateRequired: Bool = false
         
-        public init() {
-            // 체크 로직 수행
-        }
+        public init() {}
     }
     
     public enum Action: BindableAction {

--- a/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingSplash/OnboardingSplashView.swift
+++ b/Namo_SwiftUI/Projects/Feature/Onboarding/Sources/OnboardingSplash/OnboardingSplashView.swift
@@ -40,7 +40,7 @@ public struct OnboardingSplashView: View {
                 title: "업데이트가 필요합니다.",
                 content: "업데이트가 필요합니다.",
                 confirmAction: {
-                    // appStore 열기
+                    store.send(.goUpdateButtonTapped)
                 }
             )
         }

--- a/Namo_SwiftUI/Projects/Shared/Util/Sources/Utils/RemoteConfigManager.swift
+++ b/Namo_SwiftUI/Projects/Shared/Util/Sources/Utils/RemoteConfigManager.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import FirebaseRemoteConfig
 
-public class RemoteConfigManager {
+public final class RemoteConfigManager {
 	var remoteConfig = RemoteConfig.remoteConfig()
 	var settings = RemoteConfigSettings()
 	
@@ -28,25 +28,41 @@ public class RemoteConfigManager {
 		}
 	}
 	
-	public func getMinimumVersion() async throws -> String? {
-		do {
-			try await remoteConfig.fetch()
-			try await remoteConfig.activate()
-			return self.remoteConfig["ios_version"].stringValue
-		} catch {
-			print("Error: \(error)")
-			return nil
-		}
+	public func getMinimumVersion() async throws -> String {
+        try await remoteConfig.fetch()
+        try await remoteConfig.activate()
+        return self.remoteConfig["ios_version"].stringValue
 	}
 	
+    // 업데이트가 필요하면 true를, 필요없다면 false를
+    public func checkUpdateRequired() async throws -> Bool {
+        let minimumVersion = try await self.getMinimumVersion()
+        let currentVersion = version
+        
+        // 버전 문자열을 '.'을 기준으로 나누어 배열로 변환
+        let minimumVersionComponents = minimumVersion.split(separator: ".").map { Int($0) ?? 0 }
+        let currentVersionComponents = currentVersion.split(separator: ".").map { Int($0) ?? 0 }
+        
+        // 두 배열의 길이를 맞추기 위해 짧은 배열에 0 추가
+        let maxLength = max(minimumVersionComponents.count, currentVersionComponents.count)
+        let paddedMinimumVersion = minimumVersionComponents + Array(repeating: 0, count: maxLength - minimumVersionComponents.count)
+        let paddedCurrentVersion = currentVersionComponents + Array(repeating: 0, count: maxLength - currentVersionComponents.count)
+        
+        // 각 버전 숫자를 비교
+        for (min, cur) in zip(paddedMinimumVersion, paddedCurrentVersion) {
+            if cur < min {
+                return true // 업데이트가 필요함
+            } else if cur > min {
+                return false // 업데이트가 필요하지 않음
+            }
+        }
+        
+        return false // 두 버전이 같음
+    }
+    
 	public func getBaseUrl() async throws -> String? {
-		do {
-			try await remoteConfig.fetch()
-			try await remoteConfig.activate()
-			return self.remoteConfig["ios_baseurl"].stringValue
-		} catch {
-			print("Error: \(error)")
-			return nil
-		}
+        try await remoteConfig.fetch()
+        try await remoteConfig.activate()
+        return self.remoteConfig["ios_baseurl"].stringValue
 	}
 }

--- a/Namo_SwiftUI/Projects/Shared/Util/Sources/Utils/SharedKeys.swift
+++ b/Namo_SwiftUI/Projects/Shared/Util/Sources/Utils/SharedKeys.swift
@@ -7,4 +7,6 @@
 
 public enum SharedKeys: String {
 	case categories
+    /// 앱 버전 체크 필요 UI 표시용
+    case showUpdateRequired
 }


### PR DESCRIPTION
## **Related Issue**
> 연관된 이슈번호를 작성해주세요 
Close #188 

## **Description**
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 앱 진입시 AppCoordinaotr에서 초기 Coordi로 지정되는 Onboarding Coordinator의 첫 화면을 splash로 변경했습니다.
- 기존 스플래시의 로그인 체크 직전, RemoteConfigManager를 통한 버전 체크를 진행합니다. 
- 따라서 initialCheck -> versionCheck -> loginCheck -> Routing의 순서로 Coordinator 흐름이 변경되었습니다.
- 버전 업데이트 필요시 Splash 화면에서 표시되는 Alert를 연결했습니다.

## **Requirements for Review**
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
- `@Shared`를 사용하여 Splash화면에서 Alert 표시 플래그와 Coordinator의 플래그를 연결했습니다.
해당 부분에 `@Shared`를 사용하는 것이 적절한 지 잘 가늠이 안되는데, 의견 부탁드립니다..!
- TODO로 작성해놓은 부분들이 있는데 확인해주시고, 아시는 부분이 있으시면 멘트 부탁드립니다!
